### PR TITLE
Fix: Invitation acceptance RLS issue

### DIFF
--- a/src/pages/InvitationAccept.tsx
+++ b/src/pages/InvitationAccept.tsx
@@ -39,7 +39,8 @@ const InvitationAccept = () => {
       }
 
       try {
-        const { data, error } = await supabase
+        // First, fetch the invitation data without joins
+        const { data: invitationData, error: invitationError } = await supabase
           .from('organization_invitations')
           .select(`
             id,
@@ -48,29 +49,43 @@ const InvitationAccept = () => {
             status,
             message,
             expires_at,
-            organizations!inner(name),
-            profiles!invited_by(name)
+            organization_id,
+            invited_by
           `)
           .eq('invitation_token', token)
           .single();
 
-        if (error) throw error;
+        if (invitationError) throw invitationError;
 
-        if (!data) {
+        if (!invitationData) {
           setError('Invitation not found');
           setLoading(false);
           return;
         }
 
+        // Then fetch organization and inviter names separately
+        const [organizationResult, inviterResult] = await Promise.all([
+          supabase
+            .from('organizations')
+            .select('name')
+            .eq('id', invitationData.organization_id)
+            .single(),
+          supabase
+            .from('profiles')
+            .select('name')
+            .eq('id', invitationData.invited_by)
+            .single()
+        ]);
+
         setInvitation({
-          id: data.id,
-          email: data.email,
-          role: data.role as 'admin' | 'member',
-          status: data.status,
-          organization_name: (data.organizations as any).name,
-          inviter_name: (data.profiles as any).name,
-          message: data.message,
-          expires_at: data.expires_at
+          id: invitationData.id,
+          email: invitationData.email,
+          role: invitationData.role as 'admin' | 'member',
+          status: invitationData.status,
+          organization_name: organizationResult.data?.name || 'Unknown Organization',
+          inviter_name: inviterResult.data?.name || 'Unknown User',
+          message: invitationData.message,
+          expires_at: invitationData.expires_at
         });
 
       } catch (err: any) {


### PR DESCRIPTION
Modify InvitationAccept.tsx to fetch invitation data separately from organization and inviter data to bypass RLS restrictions.