### PR TITLE
feat: Implement team-based work order access

### DIFF
--- a/src/components/work-orders/WorkOrdersHeader.tsx
+++ b/src/components/work-orders/WorkOrdersHeader.tsx
@@ -1,38 +1,27 @@
+
 import React from 'react';
-import { Button } from "@/components/ui/button";
+import { Button } from '@/components/ui/button';
 import { Plus } from 'lucide-react';
-import { useIsMobile } from '@/hooks/use-mobile';
 
 interface WorkOrdersHeaderProps {
   onCreateClick: () => void;
+  subtitle?: string;
 }
 
-export const WorkOrdersHeader: React.FC<WorkOrdersHeaderProps> = ({ onCreateClick }) => {
-  const isMobile = useIsMobile();
-
-  if (isMobile) {
-    return (
-      <div className="space-y-4">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold tracking-tight">Work Orders</h1>
-          <p className="text-sm text-muted-foreground mt-1">Manage maintenance and repair work orders</p>
-        </div>
-        <Button onClick={onCreateClick} className="w-full h-12 text-base font-medium">
-          <Plus className="h-5 w-5 mr-2" />
-          Create Work Order
-        </Button>
-      </div>
-    );
-  }
-
+export const WorkOrdersHeader: React.FC<WorkOrdersHeaderProps> = ({
+  onCreateClick,
+  subtitle
+}) => {
   return (
-    <div className="flex items-center justify-between">
+    <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
       <div>
         <h1 className="text-3xl font-bold tracking-tight">Work Orders</h1>
-        <p className="text-muted-foreground">Manage maintenance and repair work orders</p>
+        {subtitle && (
+          <p className="text-muted-foreground mt-1">{subtitle}</p>
+        )}
       </div>
-      <Button onClick={onCreateClick} className="flex items-center gap-2">
-        <Plus className="h-4 w-4" />
+      <Button onClick={onCreateClick} className="w-full sm:w-auto">
+        <Plus className="mr-2 h-4 w-4" />
         Create Work Order
       </Button>
     </div>

--- a/src/hooks/useTeamBasedWorkOrders.ts
+++ b/src/hooks/useTeamBasedWorkOrders.ts
@@ -1,0 +1,38 @@
+
+import { useQuery } from '@tanstack/react-query';
+import { getTeamBasedWorkOrders, type TeamBasedWorkOrderFilters } from '@/services/teamBasedWorkOrderService';
+import { useTeamMembership } from '@/hooks/useTeamMembership';
+import { useOrganization } from '@/contexts/OrganizationContext';
+
+export const useTeamBasedWorkOrders = (filters: TeamBasedWorkOrderFilters = {}) => {
+  const { currentOrganization } = useOrganization();
+  const { getUserTeamIds, isLoading: teamsLoading } = useTeamMembership();
+
+  const userTeamIds = getUserTeamIds();
+
+  return useQuery({
+    queryKey: ['team-based-work-orders', currentOrganization?.id, userTeamIds, filters],
+    queryFn: () => {
+      if (!currentOrganization?.id) {
+        return [];
+      }
+      return getTeamBasedWorkOrders(currentOrganization.id, userTeamIds, filters);
+    },
+    enabled: !!currentOrganization?.id && !teamsLoading,
+    staleTime: 30 * 1000, // 30 seconds
+    refetchOnWindowFocus: true,
+    refetchOnMount: true,
+  });
+};
+
+// Hook for checking if user has team-based access
+export const useTeamBasedAccess = () => {
+  const { getUserTeamIds, isLoading: teamsLoading } = useTeamMembership();
+  const userTeamIds = getUserTeamIds();
+
+  return {
+    userTeamIds,
+    hasTeamAccess: userTeamIds.length > 0,
+    isLoading: teamsLoading
+  };
+};

--- a/src/services/teamBasedEquipmentService.ts
+++ b/src/services/teamBasedEquipmentService.ts
@@ -1,0 +1,92 @@
+
+import { supabase } from '@/integrations/supabase/client';
+import { useTeamMembership } from '@/hooks/useTeamMembership';
+
+export interface TeamAccessibleEquipment {
+  id: string;
+  name: string;
+  manufacturer: string;
+  model: string;
+  serialNumber: string;
+  status: 'active' | 'maintenance' | 'inactive';
+  location: string;
+  organizationId: string;
+  teamId: string | null;
+  teamName?: string;
+}
+
+// Get equipment that a user can access based on their team memberships
+export const getTeamAccessibleEquipment = async (
+  organizationId: string, 
+  userTeamIds: string[]
+): Promise<TeamAccessibleEquipment[]> => {
+  try {
+    console.log('🔍 Fetching team-accessible equipment for teams:', userTeamIds);
+    
+    let query = supabase
+      .from('equipment')
+      .select(`
+        id,
+        name,
+        manufacturer,
+        model,
+        serial_number,
+        status,
+        location,
+        organization_id,
+        team_id,
+        teams:team_id (
+          name
+        )
+      `)
+      .eq('organization_id', organizationId);
+
+    // If user has team memberships, filter to equipment assigned to those teams
+    // Also include unassigned equipment (team_id is null) so managers can see and assign it
+    if (userTeamIds.length > 0) {
+      query = query.or(`team_id.in.(${userTeamIds.join(',')}),team_id.is.null`);
+    } else {
+      // If user has no team memberships, only show unassigned equipment
+      query = query.is('team_id', null);
+    }
+
+    const { data, error } = await query.order('name', { ascending: true });
+
+    if (error) {
+      console.error('❌ Error fetching team-accessible equipment:', error);
+      throw error;
+    }
+
+    console.log('✅ Found team-accessible equipment:', data?.length || 0);
+
+    return (data || []).map(equipment => ({
+      id: equipment.id,
+      name: equipment.name,
+      manufacturer: equipment.manufacturer,
+      model: equipment.model,
+      serialNumber: equipment.serial_number,
+      status: equipment.status,
+      location: equipment.location,
+      organizationId: equipment.organization_id,
+      teamId: equipment.team_id,
+      teamName: equipment.teams?.name
+    }));
+  } catch (error) {
+    console.error('💥 Error in getTeamAccessibleEquipment:', error);
+    throw error;
+  }
+};
+
+// Get equipment IDs that a user can access (for work order filtering)
+export const getAccessibleEquipmentIds = async (
+  organizationId: string,
+  userTeamIds: string[]
+): Promise<string[]> => {
+  try {
+    const equipment = await getTeamAccessibleEquipment(organizationId, userTeamIds);
+    return equipment.map(e => e.id);
+  } catch (error) {
+    console.error('💥 Error getting accessible equipment IDs:', error);
+    return [];
+  }
+};


### PR DESCRIPTION
This commit implements team-based work order access control. It introduces new services, hooks, and updates to the WorkOrders page to filter work orders based on the user's team memberships and equipment assignments. This ensures that users only see work orders for equipment they have access to.