### PR TITLE
Refactor: Migrate to hCaptcha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "vite_react_shadcn_ts",
       "version": "0.0.0",
       "dependencies": {
+        "@hcaptcha/react-hcaptcha": "^1.12.0",
         "@hookform/resolvers": "^3.9.0",
-        "@marsidev/react-turnstile": "^1.1.0",
         "@radix-ui/react-accordion": "^1.2.0",
         "@radix-ui/react-alert-dialog": "^1.1.1",
         "@radix-ui/react-aspect-ratio": "^1.1.0",
@@ -756,6 +756,26 @@
       "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==",
       "license": "MIT"
     },
+    "node_modules/@hcaptcha/loader": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hcaptcha/loader/-/loader-2.0.0.tgz",
+      "integrity": "sha512-fFQH6ApU/zCCl6Y1bnbsxsp1Er/lKX+qlgljrpWDeFcenpEtoP68hExlKSXECospzKLeSWcr06cbTjlR/x3IJA==",
+      "license": "MIT"
+    },
+    "node_modules/@hcaptcha/react-hcaptcha": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@hcaptcha/react-hcaptcha/-/react-hcaptcha-1.12.0.tgz",
+      "integrity": "sha512-QiHnQQ52k8SJJSHkc3cq4TlYzag7oPd4f5ZqnjVSe4fJDSlZaOQFtu5F5AYisVslwaitdDELPVLRsRJxiiI0Aw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.9",
+        "@hcaptcha/loader": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
     "node_modules/@hookform/resolvers": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.9.0.tgz",
@@ -886,16 +906,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@marsidev/react-turnstile": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@marsidev/react-turnstile/-/react-turnstile-1.1.0.tgz",
-      "integrity": "sha512-X7bP9ZYutDd+E+klPYF+/BJHqEyyVkN4KKmZcNRr84zs3DcMoftlMAuoKqNSnqg0HE7NQ1844+TLFSJoztCdSA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^17.0.2 || ^18.0.0 || ^19.0",
-        "react-dom": "^17.0.2 || ^18.0.0 || ^19.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@hcaptcha/react-hcaptcha": "^1.12.0",
     "@hookform/resolvers": "^3.9.0",
-    "@marsidev/react-turnstile": "^1.1.0",
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-alert-dialog": "^1.1.1",
     "@radix-ui/react-aspect-ratio": "^1.1.0",

--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -5,7 +5,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Loader2, CheckCircle, XCircle } from 'lucide-react';
-import TurnstileComponent from '@/components/ui/Turnstile';
+import HCaptchaComponent from '@/components/ui/HCaptcha';
 import { supabase } from '@/integrations/supabase/client';
 
 interface SignUpFormProps {
@@ -23,7 +23,7 @@ const SignUpForm: React.FC<SignUpFormProps> = ({ onSuccess, onError, isLoading, 
     confirmPassword: '',
     organizationName: ''
   });
-  const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
+  const [hcaptchaToken, setHcaptchaToken] = useState<string | null>(null);
   const [passwordMatch, setPasswordMatch] = useState<boolean | null>(null);
 
   const handleInputChange = (field: string, value: string) => {
@@ -49,7 +49,7 @@ const SignUpForm: React.FC<SignUpFormProps> = ({ onSuccess, onError, isLoading, 
            formData.confirmPassword && 
            formData.organizationName.trim() && 
            passwordMatch === true && 
-           turnstileToken;
+           hcaptchaToken;
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -74,35 +74,35 @@ const SignUpForm: React.FC<SignUpFormProps> = ({ onSuccess, onError, isLoading, 
             name: formData.name,
             organization_name: formData.organizationName
           },
-          captchaToken: turnstileToken
+          captchaToken: hcaptchaToken
         }
       });
       
       if (error) {
         onError(error.message);
-        setTurnstileToken(null);
+        setHcaptchaToken(null);
       } else {
         onSuccess('Account created successfully! Please check your email to verify your account and complete organization setup.');
       }
     } catch (error: any) {
       onError(error.message || 'An error occurred during sign up');
-      setTurnstileToken(null);
+      setHcaptchaToken(null);
     }
     
     setIsLoading(false);
   };
 
-  const handleTurnstileVerify = (token: string) => {
-    setTurnstileToken(token);
+  const handleHCaptchaVerify = (token: string) => {
+    setHcaptchaToken(token);
   };
 
-  const handleTurnstileError = () => {
-    setTurnstileToken(null);
+  const handleHCaptchaError = () => {
+    setHcaptchaToken(null);
     onError('CAPTCHA verification failed. Please try again.');
   };
 
-  const handleTurnstileExpire = () => {
-    setTurnstileToken(null);
+  const handleHCaptchaExpire = () => {
+    setHcaptchaToken(null);
     onError('CAPTCHA expired. Please complete it again.');
   };
 
@@ -183,10 +183,10 @@ const SignUpForm: React.FC<SignUpFormProps> = ({ onSuccess, onError, isLoading, 
         )}
       </div>
       
-      <TurnstileComponent
-        onSuccess={handleTurnstileVerify}
-        onError={handleTurnstileError}
-        onExpire={handleTurnstileExpire}
+      <HCaptchaComponent
+        onSuccess={handleHCaptchaVerify}
+        onError={handleHCaptchaError}
+        onExpire={handleHCaptchaExpire}
       />
       
       <Button 

--- a/src/components/ui/HCaptcha.tsx
+++ b/src/components/ui/HCaptcha.tsx
@@ -1,23 +1,22 @@
-
 import React from 'react';
-import { Turnstile } from '@marsidev/react-turnstile';
+import HCaptcha from '@hcaptcha/react-hcaptcha';
 
-interface TurnstileComponentProps {
+interface HCaptchaComponentProps {
   onSuccess: (token: string) => void;
   onError?: () => void;
   onExpire?: () => void;
 }
 
-const TurnstileComponent: React.FC<TurnstileComponentProps> = ({
+const HCaptchaComponent: React.FC<HCaptchaComponentProps> = ({
   onSuccess,
   onError,
   onExpire
 }) => {
   return (
     <div className="flex justify-center my-4">
-      <Turnstile
-        siteKey="0x4AAAAAABl-Ka0TxW5_4bLG"
-        onSuccess={onSuccess}
+      <HCaptcha
+        sitekey="0a70b436-810e-423e-8100-14e6829a319e"
+        onVerify={onSuccess}
         onError={onError}
         onExpire={onExpire}
       />
@@ -25,4 +24,4 @@ const TurnstileComponent: React.FC<TurnstileComponentProps> = ({
   );
 };
 
-export default TurnstileComponent;
+export default HCaptchaComponent;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,18 @@ export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
     port: 8080,
+    headers: {
+      "Content-Security-Policy": [
+        "default-src 'self'",
+        "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://hcaptcha.com https://*.hcaptcha.com https://cdn.gpteng.co https://js.sentry-cdn.com",
+        "style-src 'self' 'unsafe-inline' https://hcaptcha.com https://*.hcaptcha.com https://cdn.gpteng.co",
+        "frame-src 'self' https://hcaptcha.com https://*.hcaptcha.com",
+        "connect-src 'self' https://hcaptcha.com https://*.hcaptcha.com https://lovable-api.com https://*.sentry.io https://ymxkzronkhwxzcdcbnwq.supabase.co wss://localhost:* ws://localhost:*",
+        "img-src 'self' data: https:",
+        "font-src 'self' data: https://cdn.gpteng.co",
+        "worker-src 'self' blob:"
+      ].join("; ")
+    }
   },
   plugins: [
     react(),


### PR DESCRIPTION
Migrated from Cloudflare Turnstile to hCaptcha for improved development experience.

Updated frontend components:
- Replaced `@marsidev/react-turnstile` with `@hcaptcha/react-hcaptcha`.
- Renamed `Turnstile.tsx` to `HCaptcha.tsx` and updated its implementation with the new site key (`0a70b436-810e-423e-8100-14e6829a319e`).
- Updated `SignUpForm.tsx` to use the new `HCaptcha` component and renamed related variables and handlers.

Updated backend function:
- Renamed `supabase/functions/verify-turnstile/` to `supabase/functions/verify-hcaptcha/`.
- Modified the verification endpoint to `https://hcaptcha.com/siteverify`.
- Updated the secret key environment variable name to `HCAPTCHA_SECRET_KEY`.

Adjusted CSP headers in `vite.config.ts` to remove Turnstile domains and include hCaptcha domains. Renamed remaining "turnstile" references to "hcaptcha" throughout the codebase.