### PR TITLE
Fix QR code modal mobile responsiveness

### DIFF
--- a/src/components/equipment/QRCodeDisplay.tsx
+++ b/src/components/equipment/QRCodeDisplay.tsx
@@ -6,6 +6,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Download, Copy, CheckCircle } from 'lucide-react';
 import QRCode from 'qrcode';
 import { toast } from 'sonner';
+import { useIsMobile } from '@/hooks/use-mobile';
 
 interface QRCodeDisplayProps {
   open: boolean;
@@ -18,6 +19,7 @@ const QRCodeDisplay: React.FC<QRCodeDisplayProps> = ({ open, onClose, equipmentI
   const [qrCodeDataUrl, setQrCodeDataUrl] = React.useState<string>('');
   const [copied, setCopied] = React.useState(false);
   const [selectedFormat, setSelectedFormat] = React.useState<'png' | 'jpg'>('png');
+  const isMobile = useIsMobile();
 
   // Generate QR code URL - using the new /qr/ route for seamless authentication
   const qrCodeUrl = `${window.location.origin}/qr/${equipmentId}`;
@@ -99,25 +101,25 @@ const QRCodeDisplay: React.FC<QRCodeDisplayProps> = ({ open, onClose, equipmentI
 
   return (
     <Dialog open={open} onOpenChange={(open) => !open && onClose()}>
-      <DialogContent className="max-w-md">
+      <DialogContent className={`max-w-md ${isMobile ? 'max-h-[90vh] overflow-y-auto p-4' : ''}`}>
         <DialogHeader>
           <DialogTitle>Equipment QR Code</DialogTitle>
         </DialogHeader>
         
-        <div className="space-y-6">
+        <div className={`${isMobile ? 'space-y-4' : 'space-y-6'}`}>
           {/* QR Code Display */}
           <div className="flex justify-center">
             {qrCodeDataUrl ? (
-              <div className="p-4 bg-white rounded-lg border">
+              <div className={`${isMobile ? 'p-2' : 'p-4'} bg-white rounded-lg border`}>
                 <img 
                   src={qrCodeDataUrl} 
                   alt="Equipment QR Code"
-                  className="w-64 h-64"
+                  className={isMobile ? 'w-48 h-48' : 'w-64 h-64'}
                 />
               </div>
             ) : (
-              <div className="w-64 h-64 bg-muted rounded-lg flex items-center justify-center">
-                <div className="text-muted-foreground">Generating QR code...</div>
+              <div className={`${isMobile ? 'w-48 h-48' : 'w-64 h-64'} bg-muted rounded-lg flex items-center justify-center`}>
+                <div className="text-muted-foreground text-center px-2">Generating QR code...</div>
               </div>
             )}
           </div>


### PR DESCRIPTION
The QR code modal's content was too large for some mobile screens, preventing users from scrolling to see controls. This commit implements the following changes to improve mobile responsiveness:

- Makes the dialog scrollable on mobile using `max-h-[90vh]` and `overflow-y-auto`.
- Implements responsive QR code sizing with smaller dimensions on mobile.
- Adjusts spacing and layout for mobile devices using `space-y-4` and responsive padding.
- Leverages the `useIsMobile()` hook for conditional styling.
- Improves dialog content classes to ensure the modal fits within viewport bounds.