### PR TITLE
feat: Implement auto-organization switching for QR scans

### DIFF
--- a/src/components/qr/QRRedirectHandler.tsx
+++ b/src/components/qr/QRRedirectHandler.tsx
@@ -1,0 +1,158 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { Loader2, AlertCircle, ArrowRight, RefreshCw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { useQRRedirectWithOrgSwitch } from '@/hooks/useQRRedirectWithOrgSwitch';
+
+interface QRRedirectHandlerProps {
+  equipmentId: string | undefined;
+}
+
+export const QRRedirectHandler: React.FC<QRRedirectHandlerProps> = ({ equipmentId }) => {
+  const { state, isSwitchingOrg, handleOrgSwitch, handleProceed, retry } = useQRRedirectWithOrgSwitch({
+    equipmentId,
+    onComplete: (targetPath) => {
+      // Navigation will be handled by the Navigate component below
+    }
+  });
+
+  // Loading state
+  if (state.isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-background">
+        <Card className="w-full max-w-md mx-4">
+          <CardContent className="pt-6">
+            <div className="flex flex-col items-center space-y-4">
+              <Loader2 className="h-8 w-8 animate-spin text-primary" />
+              <div className="text-center">
+                <p className="text-sm text-muted-foreground">
+                  Verifying equipment access...
+                </p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  // Direct navigation cases
+  if (state.canProceed && state.targetPath) {
+    return <Navigate to={state.targetPath} replace />;
+  }
+
+  if (state.needsAuth && state.targetPath) {
+    return <Navigate to={state.targetPath} replace />;
+  }
+
+  if (state.error && state.targetPath && !state.needsOrgSwitch) {
+    return <Navigate to={state.targetPath} replace />;
+  }
+
+  // Organization switch required
+  if (state.needsOrgSwitch && state.equipmentInfo) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-background p-4">
+        <Card className="w-full max-w-md">
+          <CardHeader className="text-center">
+            <CardTitle className="flex items-center justify-center space-x-2">
+              <ArrowRight className="h-5 w-5 text-primary" />
+              <span>Organization Switch Required</span>
+            </CardTitle>
+            <CardDescription>
+              This equipment belongs to a different organization
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="text-center space-y-2">
+              <p className="text-sm text-muted-foreground">
+                Equipment found in:
+              </p>
+              <p className="font-medium text-foreground">
+                {state.equipmentInfo.organizationName}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Your role: {state.equipmentInfo.userRole}
+              </p>
+            </div>
+
+            <div className="flex flex-col space-y-2">
+              <Button 
+                onClick={handleOrgSwitch}
+                disabled={isSwitchingOrg}
+                className="w-full"
+              >
+                {isSwitchingOrg ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Switching...
+                  </>
+                ) : (
+                  <>
+                    <ArrowRight className="mr-2 h-4 w-4" />
+                    Switch & Continue
+                  </>
+                )}
+              </Button>
+              
+              <Button 
+                variant="outline" 
+                onClick={() => window.location.href = '/scanner'}
+                className="w-full"
+              >
+                Cancel
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  // Error state with retry option
+  if (state.error) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-background p-4">
+        <Card className="w-full max-w-md">
+          <CardHeader className="text-center">
+            <CardTitle className="flex items-center justify-center space-x-2 text-destructive">
+              <AlertCircle className="h-5 w-5" />
+              <span>Access Error</span>
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>
+                {state.error}
+              </AlertDescription>
+            </Alert>
+
+            <div className="flex flex-col space-y-2">
+              <Button 
+                onClick={retry}
+                variant="outline"
+                className="w-full"
+              >
+                <RefreshCw className="mr-2 h-4 w-4" />
+                Try Again
+              </Button>
+              
+              <Button 
+                onClick={() => window.location.href = '/scanner'}
+                className="w-full"
+              >
+                Back to Scanner
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  // Fallback to scanner if no other conditions match
+  return <Navigate to="/scanner" replace />;
+};

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -289,11 +289,11 @@ export const SessionProvider: React.FC<{ children: React.ReactNode }> = ({ child
     
     const organization = sessionData.organizations.find(org => org.id === organizationId);
     if (!organization) {
-      console.warn('Organization not found:', organizationId);
-      return;
+      console.warn('❌ Organization not found:', organizationId);
+      throw new Error(`Organization ${organizationId} not found in user's organizations`);
     }
 
-    console.log('🔄 Switching to organization:', organizationId);
+    console.log('🔄 Switching to organization:', organizationId, organization.name);
     
     // Save user preference immediately
     saveOrganizationPreference(organizationId);

--- a/src/hooks/usePendingRedirectHandler.ts
+++ b/src/hooks/usePendingRedirectHandler.ts
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '@/contexts/AuthContext';
+
+/**
+ * Hook to handle pending redirects after authentication
+ */
+export const usePendingRedirectHandler = () => {
+  const navigate = useNavigate();
+  const { user, isLoading } = useAuth();
+
+  useEffect(() => {
+    if (isLoading || !user) return;
+
+    // Check for pending redirect from QR scan
+    const pendingRedirect = sessionStorage.getItem('pendingRedirect');
+    
+    if (pendingRedirect) {
+      console.log('🔗 Found pending redirect:', pendingRedirect);
+      
+      // Clear the pending redirect
+      sessionStorage.removeItem('pendingRedirect');
+      
+      // Small delay to ensure authentication is fully processed
+      setTimeout(() => {
+        navigate(pendingRedirect, { replace: true });
+      }, 100);
+    }
+  }, [user, isLoading, navigate]);
+};

--- a/src/hooks/useQRRedirectWithOrgSwitch.ts
+++ b/src/hooks/useQRRedirectWithOrgSwitch.ts
@@ -1,0 +1,197 @@
+import { useEffect, useState } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { useSession } from '@/contexts/SessionContext';
+import { getEquipmentOrganization, checkUserHasMultipleOrganizations, EquipmentOrganizationInfo } from '@/services/equipmentOrganizationService';
+import { toast } from 'sonner';
+
+export interface QRRedirectState {
+  isLoading: boolean;
+  needsAuth: boolean;
+  needsOrgSwitch: boolean;
+  canProceed: boolean;
+  error: string | null;
+  equipmentInfo: EquipmentOrganizationInfo | null;
+  targetPath: string | null;
+}
+
+interface UseQRRedirectWithOrgSwitchProps {
+  equipmentId: string | undefined;
+  onComplete?: (targetPath: string) => void;
+}
+
+export const useQRRedirectWithOrgSwitch = ({
+  equipmentId,
+  onComplete
+}: UseQRRedirectWithOrgSwitchProps) => {
+  const { user, isLoading: authLoading } = useAuth();
+  const { getCurrentOrganization, switchOrganization, refreshSession } = useSession();
+  
+  const [state, setState] = useState<QRRedirectState>({
+    isLoading: true,
+    needsAuth: false,
+    needsOrgSwitch: false,
+    canProceed: false,
+    error: null,
+    equipmentInfo: null,
+    targetPath: null
+  });
+
+  const [isSwitchingOrg, setIsSwitchingOrg] = useState(false);
+
+  useEffect(() => {
+    if (!equipmentId) {
+      setState(prev => ({
+        ...prev,
+        isLoading: false,
+        error: 'No equipment ID provided',
+        targetPath: '/scanner'
+      }));
+      return;
+    }
+
+    // Store the intended destination for post-auth redirect
+    const targetPath = `/equipment/${equipmentId}?qr=true`;
+    sessionStorage.setItem('pendingRedirect', targetPath);
+
+    if (authLoading) {
+      return; // Wait for auth to complete
+    }
+
+    if (!user) {
+      setState(prev => ({
+        ...prev,
+        isLoading: false,
+        needsAuth: true,
+        targetPath: '/auth'
+      }));
+      return;
+    }
+
+    // User is authenticated, proceed with organization check
+    checkEquipmentOrganization();
+  }, [equipmentId, user, authLoading]);
+
+  const checkEquipmentOrganization = async () => {
+    if (!equipmentId || !user) return;
+
+    try {
+      setState(prev => ({ ...prev, isLoading: true, error: null }));
+
+      // Get equipment organization info
+      const equipmentInfo = await getEquipmentOrganization(equipmentId);
+      
+      if (!equipmentInfo) {
+        setState(prev => ({
+          ...prev,
+          isLoading: false,
+          error: 'Equipment not found or access denied',
+          targetPath: '/scanner'
+        }));
+        return;
+      }
+
+      if (!equipmentInfo.userHasAccess) {
+        setState(prev => ({
+          ...prev,
+          isLoading: false,
+          error: `You don't have access to equipment in ${equipmentInfo.organizationName}`,
+          targetPath: '/scanner'
+        }));
+        return;
+      }
+
+      const currentOrg = getCurrentOrganization();
+      const targetPath = `/equipment/${equipmentId}?qr=true`;
+
+      // Check if we need to switch organizations
+      if (!currentOrg || currentOrg.id !== equipmentInfo.organizationId) {
+        console.log('🔄 Need to switch organization from', currentOrg?.id, 'to', equipmentInfo.organizationId);
+        
+        // Check if user has multiple organizations
+        const hasMultipleOrgs = await checkUserHasMultipleOrganizations();
+        
+        if (hasMultipleOrgs) {
+          setState(prev => ({
+            ...prev,
+            isLoading: false,
+            needsOrgSwitch: true,
+            equipmentInfo,
+            targetPath
+          }));
+        } else {
+          // Only one org, refresh session to ensure context is current
+          await refreshSession();
+          setState(prev => ({
+            ...prev,
+            isLoading: false,
+            canProceed: true,
+            equipmentInfo,
+            targetPath
+          }));
+        }
+      } else {
+        // Already in correct organization
+        setState(prev => ({
+          ...prev,
+          isLoading: false,
+          canProceed: true,
+          equipmentInfo,
+          targetPath
+        }));
+      }
+
+    } catch (error) {
+      console.error('❌ Error checking equipment organization:', error);
+      setState(prev => ({
+        ...prev,
+        isLoading: false,
+        error: 'Failed to verify equipment access',
+        targetPath: '/scanner'
+      }));
+    }
+  };
+
+  const handleOrgSwitch = async () => {
+    if (!state.equipmentInfo || isSwitchingOrg) return;
+
+    try {
+      setIsSwitchingOrg(true);
+      
+      console.log('🔄 Switching to organization:', state.equipmentInfo.organizationId);
+      
+      await switchOrganization(state.equipmentInfo.organizationId);
+      
+      toast.success(`Switched to ${state.equipmentInfo.organizationName}`);
+      
+      setState(prev => ({
+        ...prev,
+        needsOrgSwitch: false,
+        canProceed: true
+      }));
+
+    } catch (error) {
+      console.error('❌ Error switching organization:', error);
+      toast.error('Failed to switch organization');
+      setState(prev => ({
+        ...prev,
+        error: 'Failed to switch organization'
+      }));
+    } finally {
+      setIsSwitchingOrg(false);
+    }
+  };
+
+  const handleProceed = () => {
+    if (state.targetPath && onComplete) {
+      onComplete(state.targetPath);
+    }
+  };
+
+  return {
+    state,
+    isSwitchingOrg,
+    handleOrgSwitch,
+    handleProceed,
+    retry: checkEquipmentOrganization
+  };
+};

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -8,6 +8,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Separator } from '@/components/ui/separator';
 import { Loader2, QrCode } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
+import { usePendingRedirectHandler } from '@/hooks/usePendingRedirectHandler';
 import Logo from '@/components/ui/Logo';
 import SignUpForm from '@/components/auth/SignUpForm';
 import SignInForm from '@/components/auth/SignInForm';
@@ -21,10 +22,13 @@ const Auth = () => {
   const [success, setSuccess] = useState<string | null>(null);
   const [pendingQRScan, setPendingQRScan] = useState(false);
 
+  // Handle pending redirects after authentication
+  usePendingRedirectHandler();
+
   // Check if user came here from a QR scan
   useEffect(() => {
     const pendingRedirect = sessionStorage.getItem('pendingRedirect');
-    if (pendingRedirect) {
+    if (pendingRedirect && pendingRedirect.includes('qr=true')) {
       setPendingQRScan(true);
     }
   }, []);
@@ -32,13 +36,8 @@ const Auth = () => {
   // Redirect if already authenticated
   useEffect(() => {
     if (user && !authLoading) {
-      const pendingRedirect = sessionStorage.getItem('pendingRedirect');
-      if (pendingRedirect) {
-        sessionStorage.removeItem('pendingRedirect');
-        window.location.href = pendingRedirect;
-      } else {
-        navigate('/');
-      }
+      // The usePendingRedirectHandler will handle the redirect
+      navigate('/');
     }
   }, [user, authLoading, navigate]);
 

--- a/src/pages/EquipmentDetails.tsx
+++ b/src/pages/EquipmentDetails.tsx
@@ -41,12 +41,13 @@ const EquipmentDetails = () => {
   useEffect(() => {
     const isQRScan = searchParams.get('qr') === 'true';
     
-    // Reduced logging for performance
-    if (process.env.NODE_ENV === 'development') {
-      console.log('Equipment page:', { isQRScan, hasEquipment: !!equipment });
-    }
-    
     if (isQRScan && equipment && equipmentId && currentOrganization && !scanLogged) {
+      // Show success message for QR scan
+      toast.success('QR Code scanned successfully!', {
+        description: `Viewing ${equipment.name} in ${currentOrganization.name}`,
+        duration: 4000
+      });
+      
       logScan();
     }
   }, [equipment, equipmentId, currentOrganization, searchParams, scanLogged]);

--- a/src/pages/QRRedirect.tsx
+++ b/src/pages/QRRedirect.tsx
@@ -1,38 +1,12 @@
 
-import React, { useEffect } from 'react';
-import { useParams, Navigate } from 'react-router-dom';
-import { useAuth } from '@/contexts/AuthContext';
-import { Loader2 } from 'lucide-react';
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import { QRRedirectHandler } from '@/components/qr/QRRedirectHandler';
 
 const QRRedirect = () => {
   const { equipmentId } = useParams<{ equipmentId: string }>();
-  const { user, isLoading } = useAuth();
 
-  useEffect(() => {
-    // Store the intended destination in sessionStorage for post-login redirect
-    if (equipmentId && !user && !isLoading) {
-      sessionStorage.setItem('pendingRedirect', `/equipment/${equipmentId}?qr=true`);
-    }
-  }, [equipmentId, user, isLoading]);
-
-  if (isLoading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <Loader2 className="h-8 w-8 animate-spin" />
-      </div>
-    );
-  }
-
-  if (!equipmentId) {
-    return <Navigate to="/scanner" replace />;
-  }
-
-  if (!user) {
-    return <Navigate to="/auth" replace />;
-  }
-
-  // User is authenticated, redirect to equipment details with QR flag
-  return <Navigate to={`/equipment/${equipmentId}?qr=true`} replace />;
+  return <QRRedirectHandler equipmentId={equipmentId} />;
 };
 
 export default QRRedirect;

--- a/src/services/equipmentOrganizationService.ts
+++ b/src/services/equipmentOrganizationService.ts
@@ -1,0 +1,98 @@
+import { supabase } from '@/integrations/supabase/client';
+
+export interface EquipmentOrganizationInfo {
+  equipmentId: string;
+  organizationId: string;
+  organizationName: string;
+  userHasAccess: boolean;
+  userRole?: string;
+}
+
+/**
+ * Fetches equipment organization information without requiring current organization context
+ */
+export const getEquipmentOrganization = async (equipmentId: string): Promise<EquipmentOrganizationInfo | null> => {
+  try {
+    console.log('🔍 Fetching equipment organization for:', equipmentId);
+    
+    // Get equipment with organization info
+    const { data: equipment, error: equipmentError } = await supabase
+      .from('equipment')
+      .select(`
+        id,
+        organization_id,
+        organizations!inner(
+          id,
+          name
+        )
+      `)
+      .eq('id', equipmentId)
+      .single();
+
+    if (equipmentError) {
+      console.error('❌ Error fetching equipment:', equipmentError);
+      return null;
+    }
+
+    if (!equipment) {
+      console.log('⚠️ Equipment not found:', equipmentId);
+      return null;
+    }
+
+    // Check if current user has access to this organization
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+      console.log('❌ No authenticated user');
+      return null;
+    }
+
+    const { data: membership, error: membershipError } = await supabase
+      .from('organization_members')
+      .select('role, status')
+      .eq('organization_id', equipment.organization_id)
+      .eq('user_id', user.id)
+      .eq('status', 'active')
+      .maybeSingle();
+
+    if (membershipError) {
+      console.error('❌ Error checking organization membership:', membershipError);
+    }
+
+    const result: EquipmentOrganizationInfo = {
+      equipmentId: equipment.id,
+      organizationId: equipment.organization_id,
+      organizationName: equipment.organizations.name,
+      userHasAccess: !!membership,
+      userRole: membership?.role
+    };
+
+    console.log('✅ Equipment organization info:', result);
+    return result;
+
+  } catch (error) {
+    console.error('❌ Unexpected error in getEquipmentOrganization:', error);
+    return null;
+  }
+};
+
+/**
+ * Checks if user has access to multiple organizations
+ */
+export const checkUserHasMultipleOrganizations = async (): Promise<boolean> => {
+  try {
+    const { data: memberships, error } = await supabase
+      .from('organization_members')
+      .select('organization_id')
+      .eq('status', 'active');
+
+    if (error) {
+      console.error('❌ Error checking user organizations:', error);
+      return false;
+    }
+
+    return (memberships?.length || 0) > 1;
+  } catch (error) {
+    console.error('❌ Unexpected error checking multiple organizations:', error);
+    return false;
+  }
+};

--- a/src/utils/qrTestHelper.ts
+++ b/src/utils/qrTestHelper.ts
@@ -1,0 +1,63 @@
+/**
+ * Helper utilities for testing QR code functionality
+ * These functions help simulate and test the QR redirect flow
+ */
+
+export const QRTestHelper = {
+  /**
+   * Simulate scanning a QR code by navigating to the QR redirect URL
+   */
+  simulateQRScan: (equipmentId: string) => {
+    console.log('🧪 Simulating QR scan for equipment:', equipmentId);
+    window.location.href = `/qr/${equipmentId}`;
+  },
+
+  /**
+   * Check if there's a pending redirect in session storage
+   */
+  checkPendingRedirect: () => {
+    const pendingRedirect = sessionStorage.getItem('pendingRedirect');
+    console.log('🔍 Pending redirect:', pendingRedirect);
+    return pendingRedirect;
+  },
+
+  /**
+   * Clear any pending redirects (useful for testing)
+   */
+  clearPendingRedirect: () => {
+    sessionStorage.removeItem('pendingRedirect');
+    console.log('🗑️ Cleared pending redirect');
+  },
+
+  /**
+   * Set a test pending redirect (for testing auth flow)
+   */
+  setTestPendingRedirect: (equipmentId: string) => {
+    const testRedirect = `/equipment/${equipmentId}?qr=true`;
+    sessionStorage.setItem('pendingRedirect', testRedirect);
+    console.log('🧪 Set test pending redirect:', testRedirect);
+  },
+
+  /**
+   * Get current organization context for debugging
+   */
+  debugOrganizationContext: () => {
+    const sessionData = localStorage.getItem('equipqr_session_data');
+    if (sessionData) {
+      try {
+        const parsed = JSON.parse(sessionData);
+        console.log('🏢 Current session organizations:', parsed.organizations);
+        console.log('🎯 Current organization ID:', parsed.currentOrganizationId);
+        return parsed;
+      } catch (error) {
+        console.error('❌ Error parsing session data:', error);
+      }
+    }
+    return null;
+  }
+};
+
+// Make available globally for testing in browser console
+if (typeof window !== 'undefined') {
+  (window as any).QRTestHelper = QRTestHelper;
+}


### PR DESCRIPTION
Implement a plan to automatically switch the user's organization context when scanning QR codes for equipment in different organizations. This includes creating an equipment discovery service, enhancing the QR redirect logic, improving the equipment details page, and refining session context management for mobile reliability.