### PR TITLE
feat: Add equipment working hours to PM PDF

### DIFF
--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -106,7 +106,11 @@ export class PMChecklistPDFGenerator {
     
     // Equipment Information
     if (equipment?.name) {
-      this.addText(`Equipment: ${equipment.name}`, this.margin, 12, 'bold');
+      const workingHours = equipment.working_hours;
+      const equipmentText = workingHours && workingHours > 0 
+        ? `Equipment: ${equipment.name} (${workingHours} hours)`
+        : `Equipment: ${equipment.name}`;
+      this.addText(equipmentText, this.margin, 12, 'bold');
     }
     
     // Assignee/Certifying Mechanic


### PR DESCRIPTION
Update PDF generator to include equipment working hours in the equipment line. If working hours are available, they will be displayed in parentheses after the equipment name, formatted as "(X Hrs.)". If no working hours are set, this information will be omitted.