### PR TITLE
Refactor itemized costs editor

### DIFF
--- a/src/components/work-orders/InlineEditWorkOrderCosts.tsx
+++ b/src/components/work-orders/InlineEditWorkOrderCosts.tsx
@@ -35,7 +35,8 @@ const InlineEditWorkOrderCosts: React.FC<InlineEditWorkOrderCostsProps> = ({
     getUpdatedCosts,
     getDeletedCosts,
     validateCosts,
-    resetCosts
+    resetCosts,
+    ensureMinimumCosts
   } = useWorkOrderCostsState(costs);
 
   const createCostMutation = useCreateWorkOrderCost();
@@ -56,6 +57,7 @@ const InlineEditWorkOrderCosts: React.FC<InlineEditWorkOrderCostsProps> = ({
 
   const handleStartEdit = () => {
     resetCosts(costs);
+    ensureMinimumCosts();
     setIsEditing(true);
   };
 

--- a/src/components/work-orders/WorkOrderCostsEditor.tsx
+++ b/src/components/work-orders/WorkOrderCostsEditor.tsx
@@ -61,50 +61,50 @@ const WorkOrderCostsEditor: React.FC<WorkOrderCostsEditorProps> = ({
         </p>
       )}
 
-      {costs.length > 0 && (
-        <div className="space-y-3">
-          {/* Desktop Headers */}
-          {!isMobile && (
-            <div className="grid grid-cols-4 gap-4 text-sm font-medium text-muted-foreground px-3">
-              <div>Description</div>
-              <div>Quantity</div>
-              <div>Unit Price</div>
-              <div className="text-right">Total</div>
-            </div>
-          )}
-
-          {/* Cost Items */}
-          <div className="space-y-3">
-            {costs.map((cost) => (
-              <div key={cost.id}>
-                {isMobile ? (
-                  <MobileCostItem 
-                    cost={cost}
-                    onRemoveCost={onRemoveCost}
-                    onUpdateCost={onUpdateCost}
-                    canRemove={canRemove}
-                  />
-                ) : (
-                  <DesktopCostItem 
-                    cost={cost}
-                    onRemoveCost={onRemoveCost}
-                    onUpdateCost={onUpdateCost}
-                    canRemove={canRemove}
-                  />
-                )}
-              </div>
-            ))}
+      <div className="space-y-3">
+        {/* Desktop Headers */}
+        {!isMobile && (
+          <div className="grid grid-cols-4 gap-4 text-sm font-medium text-muted-foreground px-3">
+            <div>Description</div>
+            <div>Quantity</div>
+            <div>Unit Price</div>
+            <div className="text-right">Total</div>
           </div>
+        )}
 
-          {/* Subtotal */}
+        {/* Cost Items */}
+        <div className="space-y-3">
+          {costs.map((cost) => (
+            <div key={cost.id}>
+              {isMobile ? (
+                <MobileCostItem 
+                  cost={cost}
+                  onRemoveCost={onRemoveCost}
+                  onUpdateCost={onUpdateCost}
+                  canRemove={canRemove}
+                />
+              ) : (
+                <DesktopCostItem 
+                  cost={cost}
+                  onRemoveCost={onRemoveCost}
+                  onUpdateCost={onUpdateCost}
+                  canRemove={canRemove}
+                />
+              )}
+            </div>
+          ))}
+        </div>
+
+        {/* Subtotal */}
+        {costs.length > 0 && (
           <div className="border-t pt-4">
             <div className="flex items-center justify-between text-lg font-semibold">
               <span>Subtotal:</span>
               <span>{formatCurrency(calculateSubtotal())}</span>
             </div>
           </div>
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 };

--- a/src/hooks/useWorkOrderCostsState.ts
+++ b/src/hooks/useWorkOrderCostsState.ts
@@ -98,6 +98,13 @@ export const useWorkOrderCostsState = (initialCosts: WorkOrderCost[] = []) => {
     })));
   }, []);
 
+  const ensureMinimumCosts = useCallback(() => {
+    const visibleCosts = costs.filter(cost => !cost.isDeleted);
+    if (visibleCosts.length === 0) {
+      addCost();
+    }
+  }, [costs, addCost]);
+
   return {
     costs: costs.filter(cost => !cost.isDeleted),
     addCost,
@@ -108,6 +115,7 @@ export const useWorkOrderCostsState = (initialCosts: WorkOrderCost[] = []) => {
     getUpdatedCosts,
     getDeletedCosts,
     validateCosts,
-    resetCosts
+    resetCosts,
+    ensureMinimumCosts
   };
 };


### PR DESCRIPTION
Refactor the itemized costs component to ensure input fields are always visible when editing, regardless of whether cost items exist. This includes modifying `WorkOrderCostsEditor` to always render the form structure, enhancing `useWorkOrderCostsState` with `ensureMinimumCosts` to add an empty cost item if needed, and updating `InlineEditWorkOrderCosts` to call this method upon entering edit mode.