### PR TITLE
Fix team assignment logic

### DIFF
--- a/src/components/work-orders/WorkOrderAcceptanceModal.tsx
+++ b/src/components/work-orders/WorkOrderAcceptanceModal.tsx
@@ -17,7 +17,7 @@ interface WorkOrderAcceptanceModalProps {
   onClose: () => void;
   workOrder: any;
   organizationId: string;
-  onAccept: (assigneeId?: string, teamId?: string) => Promise<void>;
+  onAccept: (assigneeId?: string) => Promise<void>;
 }
 
 interface AssigneeOption {
@@ -116,9 +116,8 @@ const WorkOrderAcceptanceModal: React.FC<WorkOrderAcceptanceModalProps> = ({
     setIsSubmitting(true);
     try {
       const assigneeId = selectedAssignee === 'unassigned' ? undefined : selectedAssignee;
-      const teamId = equipment?.team_id || undefined;
       
-      await onAccept(assigneeId, teamId);
+      await onAccept(assigneeId);
       onClose();
       
       toast.success('Work order accepted successfully');

--- a/src/components/work-orders/WorkOrderAssignmentHover.tsx
+++ b/src/components/work-orders/WorkOrderAssignmentHover.tsx
@@ -30,7 +30,6 @@ export const WorkOrderAssignmentHover: React.FC<WorkOrderAssignmentHoverProps> =
     setIsAssigning(true);
     try {
       let assigneeId = null;
-      let teamId = null;
       
       if (assignmentData.type === 'assign') {
         assigneeId = assignmentData.id;
@@ -39,7 +38,6 @@ export const WorkOrderAssignmentHover: React.FC<WorkOrderAssignmentHoverProps> =
       await assignmentMutation.mutateAsync({
         workOrderId: workOrder.id,
         assigneeId,
-        teamId,
         organizationId: workOrder.organization_id
       });
       

--- a/src/components/work-orders/WorkOrderAssignmentSelector.tsx
+++ b/src/components/work-orders/WorkOrderAssignmentSelector.tsx
@@ -33,7 +33,6 @@ const WorkOrderAssignmentSelector: React.FC<WorkOrderAssignmentSelectorProps> = 
       quickAssignmentMutation.mutate({
         workOrderId: workOrder.id,
         assigneeId: null,
-        teamId: null,
         organizationId
       });
       onCancel();
@@ -46,7 +45,6 @@ const WorkOrderAssignmentSelector: React.FC<WorkOrderAssignmentSelectorProps> = 
     quickAssignmentMutation.mutate({
       workOrderId: workOrder.id,
       assigneeId: option.id,
-      teamId: null,
       organizationId
     });
     onCancel();

--- a/src/components/work-orders/WorkOrderStatusManager.tsx
+++ b/src/components/work-orders/WorkOrderStatusManager.tsx
@@ -107,14 +107,13 @@ const WorkOrderStatusManager: React.FC<WorkOrderStatusManagerProps> = ({
     await updateStatus(newStatus);
   };
 
-  const handleAcceptance = async (assigneeId?: string, teamId?: string) => {
+  const handleAcceptance = async (assigneeId?: string) => {
     if (!currentOrganization) return;
     
     await acceptanceMutation.mutateAsync({
       workOrderId: workOrder.id,
       organizationId: currentOrganization.id,
-      assigneeId,
-      teamId
+      assigneeId
     });
 
     if (onStatusUpdate) {

--- a/src/hooks/useQuickWorkOrderAssignment.ts
+++ b/src/hooks/useQuickWorkOrderAssignment.ts
@@ -9,28 +9,25 @@ export const useQuickWorkOrderAssignment = () => {
     mutationFn: async ({ 
       workOrderId, 
       assigneeId, 
-      teamId, 
       organizationId 
     }: { 
       workOrderId: string; 
       assigneeId?: string | null; 
-      teamId?: string | null; 
       organizationId: string 
     }) => {
       // Determine the new status based on assignment
       let newStatus = 'submitted';
-      if (assigneeId || teamId) {
+      if (assigneeId) {
         newStatus = 'assigned';
       }
 
       const updateData: any = {
         assignee_id: assigneeId || null,
-        team_id: teamId || null,
         status: newStatus
       };
 
       // Only set acceptance_date if actually assigning
-      if (assigneeId || teamId) {
+      if (assigneeId) {
         updateData.acceptance_date = new Date().toISOString();
       } else {
         updateData.acceptance_date = null;
@@ -43,8 +40,8 @@ export const useQuickWorkOrderAssignment = () => {
 
       if (error) throw error;
     },
-    onSuccess: (_, { assigneeId, teamId, organizationId }) => {
-      const message = assigneeId || teamId ? 'Work order assigned successfully' : 'Work order unassigned successfully';
+    onSuccess: (_, { assigneeId, organizationId }) => {
+      const message = assigneeId ? 'Work order assigned successfully' : 'Work order unassigned successfully';
       toast.success(message);
       
       // Invalidate all work order related queries with partial matching

--- a/src/hooks/useWorkOrderAcceptance.ts
+++ b/src/hooks/useWorkOrderAcceptance.ts
@@ -8,14 +8,13 @@ interface AcceptWorkOrderParams {
   workOrderId: string;
   organizationId: string;
   assigneeId?: string;
-  teamId?: string;
 }
 
 export const useWorkOrderAcceptance = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async ({ workOrderId, organizationId, assigneeId, teamId }: AcceptWorkOrderParams) => {
+    mutationFn: async ({ workOrderId, organizationId, assigneeId }: AcceptWorkOrderParams) => {
       // Get organization member count to determine if single-user org
       const { data: orgMembers } = await supabase
         .from('organization_members')
@@ -46,10 +45,6 @@ export const useWorkOrderAcceptance = () => {
       // Add assignment if provided or if single-user org
       if (assigneeId || isSingleUserOrg) {
         updateData.assignee_id = assigneeId;
-      }
-
-      if (teamId) {
-        updateData.team_id = teamId;
       }
 
       // Update the work order

--- a/src/pages/WorkOrders.tsx
+++ b/src/pages/WorkOrders.tsx
@@ -77,14 +77,13 @@ const WorkOrders = () => {
     setAcceptanceModal({ open: true, workOrder });
   };
 
-  const handleAcceptance = async (assigneeId?: string, teamId?: string) => {
+  const handleAcceptance = async (assigneeId?: string) => {
     if (!currentOrganization || !acceptanceModal.workOrder) return;
     
     await acceptanceMutation.mutateAsync({
       workOrderId: acceptanceModal.workOrder.id,
       organizationId: currentOrganization.id,
-      assigneeId,
-      teamId
+      assigneeId
     });
 
     setAcceptanceModal({ open: false, workOrder: null });


### PR DESCRIPTION
Remove direct team assignment from work orders. Update assignment hooks and components to use the correct work order -> equipment -> team relationship for team information. Remove `team_id` updates and parameters where they are no longer relevant.