### PR TITLE
Fix billing page context issues

### DIFF
--- a/src/components/billing/LicenseMemberBilling.tsx
+++ b/src/components/billing/LicenseMemberBilling.tsx
@@ -6,7 +6,6 @@ import { Users, AlertCircle, Calendar } from 'lucide-react';
 import { useOrganizationMembers } from '@/hooks/useOrganizationMembers';
 import { useSlotAvailability } from '@/hooks/useOrganizationSlots';
 import { useSimpleOrganization } from '@/contexts/SimpleOrganizationContext';
-import { useSession } from '@/contexts/SessionContext';
 import { calculateLicenseBilling, hasLicenses, getLicenseStatus } from '@/utils/licenseBillingUtils';
 import PurchaseLicensesButton from '@/components/billing/PurchaseLicensesButton';
 import MemberTable from '@/components/billing/MemberTable';
@@ -14,13 +13,11 @@ import { useIsMobile } from '@/hooks/use-mobile';
 
 const LicenseMemberBilling: React.FC = () => {
   const { currentOrganization } = useSimpleOrganization();
-  const { getCurrentOrganization } = useSession();
   const { data: members = [], isLoading: membersLoading } = useOrganizationMembers(currentOrganization?.id || '');
   const { data: slotAvailability, isLoading: slotsLoading } = useSlotAvailability(currentOrganization?.id || '');
   const isMobile = useIsMobile();
 
-  const sessionOrganization = getCurrentOrganization();
-  const userRole = sessionOrganization?.userRole;
+  const userRole = currentOrganization?.userRole;
   const canManageBilling = ['owner', 'admin'].includes(userRole || '');
 
   if (membersLoading || slotsLoading) {

--- a/src/components/billing/ManageSubscriptionButton.tsx
+++ b/src/components/billing/ManageSubscriptionButton.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Button } from '@/components/ui/button';
 import { Settings } from 'lucide-react';
 import { useSubscription } from '@/hooks/useSubscription';
-import { useSession } from '@/contexts/SessionContext';
+import { useSimpleOrganization } from '@/contexts/SimpleOrganizationContext';
 import { toast } from 'sonner';
 
 interface ManageSubscriptionButtonProps {
@@ -18,9 +18,8 @@ const ManageSubscriptionButton: React.FC<ManageSubscriptionButtonProps> = ({
   className = ''
 }) => {
   const { openCustomerPortal } = useSubscription();
-  const { getCurrentOrganization } = useSession();
+  const { currentOrganization } = useSimpleOrganization();
   
-  const currentOrganization = getCurrentOrganization();
   const userRole = currentOrganization?.userRole;
   
   // Only allow owners and admins to manage subscriptions

--- a/src/components/billing/PurchaseLicensesButton.tsx
+++ b/src/components/billing/PurchaseLicensesButton.tsx
@@ -14,7 +14,6 @@ import {
 } from '@/components/ui/dialog';
 import { ShoppingCart, Users } from 'lucide-react';
 import { useSimpleOrganization } from '@/contexts/SimpleOrganizationContext';
-import { useSession } from '@/contexts/SessionContext';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
 import { useIsMobile } from '@/hooks/use-mobile';
@@ -31,14 +30,12 @@ const PurchaseLicensesButton: React.FC<PurchaseLicensesButtonProps> = ({
   className = ""
 }) => {
   const { currentOrganization } = useSimpleOrganization();
-  const { getCurrentOrganization } = useSession();
   const [isPurchasing, setIsPurchasing] = useState(false);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [quantity, setQuantity] = useState(1);
   const isMobile = useIsMobile();
 
-  const sessionOrganization = getCurrentOrganization();
-  const userRole = sessionOrganization?.userRole;
+  const userRole = currentOrganization?.userRole;
   const canManageBilling = ['owner', 'admin'].includes(userRole || '');
 
   const handlePurchase = async () => {

--- a/src/components/billing/PurchaseLicensesLink.tsx
+++ b/src/components/billing/PurchaseLicensesLink.tsx
@@ -12,7 +12,6 @@ import {
 } from '@/components/ui/dialog';
 import { ShoppingCart, Users } from 'lucide-react';
 import { useSimpleOrganization } from '@/contexts/SimpleOrganizationContext';
-import { useSession } from '@/contexts/SessionContext';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
 import { useIsMobile } from '@/hooks/use-mobile';
@@ -29,14 +28,12 @@ const PurchaseLicensesLink: React.FC<PurchaseLicensesLinkProps> = ({
   onClick
 }) => {
   const { currentOrganization } = useSimpleOrganization();
-  const { getCurrentOrganization } = useSession();
   const [isPurchasing, setIsPurchasing] = useState(false);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [quantity, setQuantity] = useState(1);
   const isMobile = useIsMobile();
 
-  const sessionOrganization = getCurrentOrganization();
-  const userRole = sessionOrganization?.userRole;
+  const userRole = currentOrganization?.userRole;
   const canManageBilling = ['owner', 'admin'].includes(userRole || '');
 
   const handleLinkClick = (e: React.MouseEvent) => {

--- a/src/components/billing/SimplifiedMemberBilling.tsx
+++ b/src/components/billing/SimplifiedMemberBilling.tsx
@@ -5,7 +5,6 @@ import { Badge } from '@/components/ui/badge';
 import { Users, AlertCircle } from 'lucide-react';
 import { useOrganizationMembers } from '@/hooks/useOrganizationMembers';
 import { useSimpleOrganization } from '@/contexts/SimpleOrganizationContext';
-import { useSession } from '@/contexts/SessionContext';
 import { calculateSimplifiedBilling, isFreeOrganization } from '@/utils/simplifiedBillingUtils';
 import PurchaseLicensesButton from '@/components/billing/PurchaseLicensesButton';
 import MemberTable from '@/components/billing/MemberTable';
@@ -13,12 +12,10 @@ import { useIsMobile } from '@/hooks/use-mobile';
 
 const SimplifiedMemberBilling: React.FC = () => {
   const { currentOrganization } = useSimpleOrganization();
-  const { getCurrentOrganization } = useSession();
   const { data: members = [], isLoading } = useOrganizationMembers(currentOrganization?.id || '');
   const isMobile = useIsMobile();
 
-  const sessionOrganization = getCurrentOrganization();
-  const userRole = sessionOrganization?.userRole;
+  const userRole = currentOrganization?.userRole;
   const canManageBilling = ['owner', 'admin'].includes(userRole || '');
 
   if (isLoading) {

--- a/src/components/billing/SlotBasedBilling.tsx
+++ b/src/components/billing/SlotBasedBilling.tsx
@@ -5,7 +5,6 @@ import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Users, AlertTriangle, TrendingUp } from 'lucide-react';
-import { useSession } from '@/contexts/SessionContext';
 import { useSimpleOrganization } from '@/contexts/SimpleOrganizationContext';
 import { useOrganizationMembers } from '@/hooks/useOrganizationMembers';
 import { useSlotAvailability } from '@/hooks/useOrganizationSlots';
@@ -25,13 +24,11 @@ const SlotBasedBilling: React.FC<SlotBasedBillingProps> = ({
   onPurchaseSlots,
   onUpgradeToMultiUser
 }) => {
-  const { getCurrentOrganization } = useSession();
   const { currentOrganization } = useSimpleOrganization();
   const { data: members = [] } = useOrganizationMembers(currentOrganization?.id || '');
   const { data: slotAvailability, isLoading, refetch } = useSlotAvailability(currentOrganization?.id || '');
 
-  const sessionOrganization = getCurrentOrganization();
-  const userRole = sessionOrganization?.userRole;
+  const userRole = currentOrganization?.userRole;
   const canManageBilling = ['owner', 'admin'].includes(userRole || '');
 
   // Provide safe defaults for slot availability

--- a/src/pages/Billing.tsx
+++ b/src/pages/Billing.tsx
@@ -8,7 +8,6 @@ import LicenseMemberBilling from '@/components/billing/LicenseMemberBilling';
 import ImageStorageQuota from '@/components/billing/ImageStorageQuota';
 import BillingHeader from '@/components/billing/BillingHeader';
 import { useSimpleOrganization } from '@/contexts/SimpleOrganizationContext';
-import { useSession } from '@/contexts/SessionContext';
 import { useOrganizationMembers } from '@/hooks/useOrganizationMembers';
 import { useSlotAvailability } from '@/hooks/useOrganizationSlots';
 import { useSubscription } from '@/hooks/useSubscription';
@@ -18,7 +17,7 @@ import { useIsMobile } from '@/hooks/use-mobile';
 
 const Billing = () => {
   const { currentOrganization } = useSimpleOrganization();
-  const { getCurrentOrganization } = useSession();
+  
   const { data: members = [] } = useOrganizationMembers(currentOrganization?.id || '');
   const { data: slotAvailability } = useSlotAvailability(currentOrganization?.id || '');
   const { 
@@ -37,8 +36,7 @@ const Billing = () => {
   const [fleetMapEnabled, setFleetMapEnabled] = useState(false);
 
   // Get user role for permission checks
-  const sessionOrganization = getCurrentOrganization();
-  const userRole = sessionOrganization?.userRole;
+  const userRole = currentOrganization?.userRole;
   const canManageBilling = ['owner', 'admin'].includes(userRole || '');
 
   // Calculate billing based on licenses
@@ -140,7 +138,7 @@ const Billing = () => {
       <LicenseMemberBilling />
 
       {/* Image Storage Quota */}
-      <ImageStorageQuota organizationId={sessionOrganization?.id} />
+      <ImageStorageQuota organizationId={currentOrganization?.id} />
 
       {/* Fleet Map Add-on */}
       {hasActiveLicenses && (


### PR DESCRIPTION
Update billing components to use consistent organization context. This change removes the reliance on `useSession()` and `getCurrentOrganization()` for permission checks and organization IDs, instead utilizing `currentOrganization?.userRole` and `currentOrganization?.id` from `useSimpleOrganization()`. This ensures that all billing-related components accurately reflect the selected organization from the navigation menu, resolving context mismatches.

fixes #75 