### PR TITLE
Refine license purchase permissions

### DIFF
--- a/src/components/billing/PurchaseLicensesButton.tsx
+++ b/src/components/billing/PurchaseLicensesButton.tsx
@@ -36,7 +36,7 @@ const PurchaseLicensesButton: React.FC<PurchaseLicensesButtonProps> = ({
   const isMobile = useIsMobile();
 
   const userRole = currentOrganization?.userRole;
-  const canManageBilling = ['owner', 'admin'].includes(userRole || '');
+  const canPurchaseLicenses = userRole === 'owner';
 
   const handlePurchase = async () => {
     if (!currentOrganization) {
@@ -44,8 +44,8 @@ const PurchaseLicensesButton: React.FC<PurchaseLicensesButtonProps> = ({
       return;
     }
 
-    if (!canManageBilling) {
-      toast.error('Only organization owners and admins can purchase licenses');
+    if (!canPurchaseLicenses) {
+      toast.error('Only organization owners can purchase licenses');
       return;
     }
 
@@ -83,7 +83,7 @@ const PurchaseLicensesButton: React.FC<PurchaseLicensesButtonProps> = ({
   };
 
   // Don't render the button if user doesn't have permission
-  if (!canManageBilling) {
+  if (!canPurchaseLicenses) {
     return null;
   }
 

--- a/src/components/billing/PurchaseLicensesLink.tsx
+++ b/src/components/billing/PurchaseLicensesLink.tsx
@@ -34,7 +34,7 @@ const PurchaseLicensesLink: React.FC<PurchaseLicensesLinkProps> = ({
   const isMobile = useIsMobile();
 
   const userRole = currentOrganization?.userRole;
-  const canManageBilling = ['owner', 'admin'].includes(userRole || '');
+  const canPurchaseLicenses = userRole === 'owner';
 
   const handleLinkClick = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -44,7 +44,7 @@ const PurchaseLicensesLink: React.FC<PurchaseLicensesLinkProps> = ({
       onClick();
     }
     
-    if (canManageBilling) {
+    if (canPurchaseLicenses) {
       setDialogOpen(true);
     }
   };
@@ -55,8 +55,8 @@ const PurchaseLicensesLink: React.FC<PurchaseLicensesLinkProps> = ({
       return;
     }
 
-    if (!canManageBilling) {
-      toast.error('Only organization owners and admins can purchase licenses');
+    if (!canPurchaseLicenses) {
+      toast.error('Only organization owners can purchase licenses');
       return;
     }
 
@@ -95,8 +95,8 @@ const PurchaseLicensesLink: React.FC<PurchaseLicensesLinkProps> = ({
 
   const monthlyTotal = quantity * 10;
 
-  // Render as clickable link for owners/admins, plain text for others
-  const linkContent = canManageBilling ? (
+  // Render as clickable link for owners, plain text for others
+  const linkContent = canPurchaseLicenses ? (
     <button 
       onClick={handleLinkClick}
       className={`text-primary hover:text-primary/80 underline underline-offset-4 transition-colors ${className}`}
@@ -114,7 +114,7 @@ const PurchaseLicensesLink: React.FC<PurchaseLicensesLinkProps> = ({
     <>
       {linkContent}
       
-      {canManageBilling && (
+      {canPurchaseLicenses && (
         <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
           <DialogContent className="sm:max-w-md mx-4 sm:mx-0">
             <DialogHeader>

--- a/src/pages/Billing.tsx
+++ b/src/pages/Billing.tsx
@@ -38,6 +38,7 @@ const Billing = () => {
   // Get user role for permission checks
   const userRole = currentOrganization?.userRole;
   const canManageBilling = ['owner', 'admin'].includes(userRole || '');
+  const canPurchaseLicenses = userRole === 'owner';
 
   // Calculate billing based on licenses
   const billing = slotAvailability ? calculateLicenseBilling(members, slotAvailability, storageUsedGB, fleetMapEnabled) : null;
@@ -127,7 +128,7 @@ const Billing = () => {
             <div className="flex items-start gap-2 text-amber-800">
               <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
               <span className="text-sm">
-                <strong>Limited Access:</strong> Only organization owners and admins can manage billing settings and purchase licenses.
+                <strong>Limited Access:</strong> Only organization owners and admins can manage billing settings. Only organization owners can purchase licenses.
               </span>
             </div>
           </CardContent>

--- a/supabase/functions/purchase-user-licenses/index.ts
+++ b/supabase/functions/purchase-user-licenses/index.ts
@@ -63,9 +63,9 @@ serve(async (req) => {
       throw new Error("Failed to verify organization membership");
     }
 
-    if (!membership || !['owner', 'admin'].includes(membership.role)) {
+    if (!membership || membership.role !== 'owner') {
       logStep("Authorization failed", { membership });
-      throw new Error("Insufficient permissions to purchase licenses");
+      throw new Error("Only organization owners can purchase licenses");
     }
     logStep("Authorization verified", { role: membership.role });
 


### PR DESCRIPTION
Update frontend components and backend function to enforce owner-only permissions for purchasing licenses. This includes modifying `PurchaseLicensesButton.tsx`, `PurchaseLicensesLink.tsx`, and the `purchase-user-licenses` edge function to restrict license purchases to organization owners. The `Billing.tsx` component will also be updated to differentiate between general billing management permissions (owner/admin) and license purchasing permissions (owner only).