### PR TITLE
Fix batch assignment of work orders

### DIFF
--- a/src/hooks/useBatchAssignUnassignedWorkOrders.ts
+++ b/src/hooks/useBatchAssignUnassignedWorkOrders.ts
@@ -32,8 +32,7 @@ export const useBatchAssignUnassignedWorkOrders = () => {
         .select('id')
         .eq('organization_id', organizationId)
         .eq('status', 'submitted')
-        .is('assignee_id', null)
-        .is('team_id', null);
+        .is('assignee_id', null);
 
       if (ordersError) throw ordersError;
 


### PR DESCRIPTION
The `useBatchAssignUnassignedWorkOrders` hook was incorrectly filtering work orders by `team_id`, which does not exist on the `work_orders` table. This commit removes the invalid `team_id` filter, ensuring that batch assignment of unassigned work orders functions correctly by focusing on orders with a null `assignee_id`.