### PR TITLE
Fix SegmentedProgress rounded corners

### DIFF
--- a/src/components/ui/segmented-progress.tsx
+++ b/src/components/ui/segmented-progress.tsx
@@ -34,7 +34,7 @@ const SegmentedProgress = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "relative h-4 w-full overflow-hidden rounded-full bg-secondary flex",
+      "relative h-4 w-full overflow-hidden rounded-md bg-secondary flex",
       className
     )}
   >


### PR DESCRIPTION
Update SegmentedProgress component to use `rounded-md` instead of `rounded-full` to remove rounded corners from the left and right-most sections of the progress bar.