### PR TITLE
Fix: Synchronize organization context on equipment page

### DIFF
--- a/src/hooks/useEquipmentFiltering.ts
+++ b/src/hooks/useEquipmentFiltering.ts
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react';
-import { useEquipmentByOrganization, useTeamsByOrganization } from '@/hooks/useSupabaseData';
+import { useSyncEquipmentByOrganization, useSyncTeamsByOrganization } from '@/services/syncDataService';
 import { usePermissions } from '@/hooks/usePermissions';
 
 export interface EquipmentFilters {
@@ -38,14 +38,14 @@ const initialSort: SortConfig = {
   direction: 'asc'
 };
 
-export const useEquipmentFiltering = () => {
+export const useEquipmentFiltering = (organizationId?: string) => {
   const [filters, setFilters] = useState<EquipmentFilters>(initialFilters);
   const [sortConfig, setSortConfig] = useState<SortConfig>(initialSort);
   const [showAdvancedFilters, setShowAdvancedFilters] = useState(false);
 
-  // Get equipment data - now filtered by RLS policies based on team membership
-  const { data: equipment = [], isLoading } = useEquipmentByOrganization();
-  const { data: teams = [] } = useTeamsByOrganization();
+  // Get equipment data using explicit organization ID
+  const { data: equipment = [], isLoading } = useSyncEquipmentByOrganization(organizationId);
+  const { data: teams = [] } = useSyncTeamsByOrganization(organizationId);
   const { canManageOrganization } = usePermissions();
 
   // Extract unique values for filter options

--- a/src/pages/Equipment.tsx
+++ b/src/pages/Equipment.tsx
@@ -16,7 +16,7 @@ const Equipment = () => {
   const { currentOrganization } = useSimpleOrganization();
   const { canCreateEquipment } = usePermissions();
   
-  // Use the new enhanced filtering hook
+  // Use the new enhanced filtering hook with explicit organization ID
   const {
     filters,
     sortConfig,
@@ -31,7 +31,7 @@ const Equipment = () => {
     clearFilters,
     applyQuickFilter,
     setShowAdvancedFilters
-  } = useEquipmentFiltering();
+  } = useEquipmentFiltering(currentOrganization?.id);
   
   const [showForm, setShowForm] = useState(false);
   const [editingEquipment, setEditingEquipment] = useState(null);


### PR DESCRIPTION
Synchronizes the organization context between the UI and data fetching layers on the equipment page. This resolves an issue where users with access to multiple organizations would not see the correct equipment when switching contexts. The `useEquipmentFiltering` hook now accepts an explicit `organizationId` to ensure data fetching aligns with the selected organization.