### PR TITLE
Fix dashboard organization context

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -2,20 +2,20 @@
 import React, { useEffect } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Package, Wrench, Users, ClipboardList, TrendingUp, AlertTriangle } from 'lucide-react';
-import { useSession } from '@/contexts/SessionContext';
+import { useSimpleOrganization } from '@/contexts/SimpleOrganizationContext';
 import { useDashboardStats, useEquipmentByOrganization, useAllWorkOrders } from '@/hooks/useSupabaseData';
 import { Badge } from '@/components/ui/badge';
 import { Link, useNavigate } from 'react-router-dom';
 
 const Dashboard = () => {
-  const { getCurrentOrganization, isLoading: sessionLoading } = useSession();
-  const currentOrganization = getCurrentOrganization();
+  const { currentOrganization, isLoading: orgLoading } = useSimpleOrganization();
+  const organizationId = currentOrganization?.id;
   
-  const { data: stats, isLoading: statsLoading } = useDashboardStats();
-  const { data: equipment, isLoading: equipmentLoading } = useEquipmentByOrganization();
-  const { data: workOrders, isLoading: workOrdersLoading } = useAllWorkOrders();
+  const { data: stats, isLoading: statsLoading } = useDashboardStats(organizationId);
+  const { data: equipment, isLoading: equipmentLoading } = useEquipmentByOrganization(organizationId);
+  const { data: workOrders, isLoading: workOrdersLoading } = useAllWorkOrders(organizationId);
 
-  const isLoading = sessionLoading || statsLoading;
+  const isLoading = orgLoading || statsLoading;
 
   // Debug logging for organization context
   useEffect(() => {


### PR DESCRIPTION
The dashboard was not displaying correct organization information due to several issues:
- `Dashboard.tsx` was not passing the `organizationId` to data fetching hooks.
- The dashboard was using `SessionContext` instead of the standardized `SimpleOrganizationContext`.
- Data fetching services (`getAllWorkOrdersByOrganization`, `getTeamsByOrganization`) had nested query patterns causing RLS context loss.

This commit addresses these issues by:
- Updating `Dashboard.tsx` to use `SimpleOrganizationContext` and pass the `organizationId` to hooks.
- Restructuring data fetching services to avoid RLS context loss.
- Updating hook dependencies for proper organization switching.