### PR TITLE
Refactor: Improve type safety

### DIFF
--- a/src/components/equipment/EquipmentForm.tsx
+++ b/src/components/equipment/EquipmentForm.tsx
@@ -11,7 +11,7 @@ import { Form } from "@/components/ui/form";
 import CustomAttributesSection from './CustomAttributesSection';
 import { useCustomAttributes, type CustomAttribute } from '@/hooks/useCustomAttributes';
 import { useEquipmentForm } from '@/hooks/useEquipmentForm';
-import { type EquipmentFormData } from '@/types/equipment';
+import { type EquipmentRecord } from '@/types/equipment';
 import EquipmentBasicInfoSection from './form/EquipmentBasicInfoSection';
 import EquipmentStatusLocationSection from './form/EquipmentStatusLocationSection';
 import EquipmentNotesSection from './form/EquipmentNotesSection';
@@ -21,7 +21,7 @@ import TeamSelectionSection from './form/TeamSelectionSection';
 interface EquipmentFormProps {
   open: boolean;
   onClose: () => void;
-  equipment?: any;
+  equipment?: EquipmentRecord;
 }
 
 const EquipmentForm: React.FC<EquipmentFormProps> = ({ open, onClose, equipment }) => {

--- a/src/components/equipment/QRCodeDisplay.tsx
+++ b/src/components/equipment/QRCodeDisplay.tsx
@@ -24,13 +24,7 @@ const QRCodeDisplay: React.FC<QRCodeDisplayProps> = ({ open, onClose, equipmentI
   // Generate QR code URL - using the new /qr/ route for seamless authentication
   const qrCodeUrl = `${window.location.origin}/qr/${equipmentId}`;
 
-  React.useEffect(() => {
-    if (open && equipmentId) {
-      generateQRCode();
-    }
-  }, [open, equipmentId]);
-
-  const generateQRCode = async () => {
+  const generateQRCode = React.useCallback(async () => {
     try {
       const dataUrl = await QRCode.toDataURL(qrCodeUrl, {
         width: 256,
@@ -45,7 +39,13 @@ const QRCodeDisplay: React.FC<QRCodeDisplayProps> = ({ open, onClose, equipmentI
       console.error('Error generating QR code:', error);
       toast.error('Failed to generate QR code');
     }
-  };
+  }, [qrCodeUrl]);
+
+  React.useEffect(() => {
+    if (open && equipmentId) {
+      generateQRCode();
+    }
+  }, [open, equipmentId, generateQRCode]);
 
   // Sanitize equipment name for filename
   const sanitizeFilename = (name: string) => {

--- a/src/components/equipment/form/EquipmentBasicInfoSection.tsx
+++ b/src/components/equipment/form/EquipmentBasicInfoSection.tsx
@@ -3,9 +3,10 @@ import { Card, CardContent } from "@/components/ui/card";
 import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { UseFormReturn } from 'react-hook-form';
+import { type EquipmentFormData } from '@/types/equipment';
 
 interface EquipmentBasicInfoSectionProps {
-  form: UseFormReturn<any>;
+  form: UseFormReturn<EquipmentFormData>;
 }
 
 const EquipmentBasicInfoSection: React.FC<EquipmentBasicInfoSectionProps> = ({ form }) => {

--- a/src/components/equipment/form/EquipmentNotesSection.tsx
+++ b/src/components/equipment/form/EquipmentNotesSection.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Textarea } from "@/components/ui/textarea";
 import { UseFormReturn } from 'react-hook-form';
+import { type EquipmentFormData } from '@/types/equipment';
 
 interface EquipmentNotesSectionProps {
-  form: UseFormReturn<any>;
+  form: UseFormReturn<EquipmentFormData>;
 }
 
 const EquipmentNotesSection: React.FC<EquipmentNotesSectionProps> = ({ form }) => {

--- a/src/components/equipment/form/EquipmentStatusLocationSection.tsx
+++ b/src/components/equipment/form/EquipmentStatusLocationSection.tsx
@@ -4,9 +4,10 @@ import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/comp
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { UseFormReturn } from 'react-hook-form';
+import { type EquipmentFormData } from '@/types/equipment';
 
 interface EquipmentStatusLocationSectionProps {
-  form: UseFormReturn<any>;
+  form: UseFormReturn<EquipmentFormData>;
 }
 
 const EquipmentStatusLocationSection: React.FC<EquipmentStatusLocationSectionProps> = ({ form }) => {

--- a/src/components/equipment/form/TeamSelectionSection.tsx
+++ b/src/components/equipment/form/TeamSelectionSection.tsx
@@ -8,7 +8,7 @@ import { usePermissions } from '@/hooks/usePermissions';
 import { Loader2 } from 'lucide-react';
 
 interface TeamSelectionSectionProps {
-  form: UseFormReturn<any>;
+  form: UseFormReturn<import('@/types/equipment').EquipmentFormData>;
 }
 
 const TeamSelectionSection: React.FC<TeamSelectionSectionProps> = ({ form }) => {

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/hooks/useEquipmentFiltering.ts
+++ b/src/hooks/useEquipmentFiltering.ts
@@ -57,12 +57,12 @@ export const useEquipmentFiltering = (organizationId?: string) => {
       manufacturers,
       locations,
       teams: teams.map(team => ({ id: team.id, name: team.name }))
-    };
+    } as const;
   }, [equipment, teams]);
 
   // Filter and sort equipment
   const filteredAndSortedEquipment = useMemo(() => {
-    let filtered = equipment.filter(item => {
+    const filtered = equipment.filter(item => {
       // Search filter
       if (filters.search) {
         const searchLower = filters.search.toLowerCase();
@@ -149,8 +149,8 @@ export const useEquipmentFiltering = (organizationId?: string) => {
 
     // Sort equipment
     filtered.sort((a, b) => {
-      let aValue: any = a[sortConfig.field as keyof typeof a];
-      let bValue: any = b[sortConfig.field as keyof typeof b];
+      let aValue: unknown = a[sortConfig.field as keyof typeof a];
+      let bValue: unknown = b[sortConfig.field as keyof typeof b];
 
       // Handle null/undefined values
       if (aValue == null && bValue == null) return 0;
@@ -159,21 +159,24 @@ export const useEquipmentFiltering = (organizationId?: string) => {
 
       // Handle date fields
       if (['installation_date', 'last_maintenance', 'warranty_expiration', 'created_at', 'updated_at'].includes(sortConfig.field)) {
-        aValue = new Date(aValue).getTime();
-        bValue = new Date(bValue).getTime();
+        aValue = new Date(aValue as string).getTime();
+        bValue = new Date(bValue as string).getTime();
       }
 
       // Handle string comparison
       if (typeof aValue === 'string' && typeof bValue === 'string') {
-        aValue = aValue.toLowerCase();
-        bValue = bValue.toLowerCase();
+        const aStr = aValue.toLowerCase();
+        const bStr = bValue.toLowerCase();
+        if (aStr < bStr) return sortConfig.direction === 'asc' ? -1 : 1;
+        if (aStr > bStr) return sortConfig.direction === 'asc' ? 1 : -1;
+        return 0;
       }
 
-      if (aValue < bValue) {
-        return sortConfig.direction === 'asc' ? -1 : 1;
-      }
-      if (aValue > bValue) {
-        return sortConfig.direction === 'asc' ? 1 : -1;
+      const aNum = Number(aValue);
+      const bNum = Number(bValue);
+      if (!Number.isNaN(aNum) && !Number.isNaN(bNum)) {
+        if (aNum < bNum) return sortConfig.direction === 'asc' ? -1 : 1;
+        if (aNum > bNum) return sortConfig.direction === 'asc' ? 1 : -1;
       }
       return 0;
     });
@@ -211,7 +214,7 @@ export const useEquipmentFiltering = (organizationId?: string) => {
     }
   };
 
-  const updateFilter = (key: keyof EquipmentFilters, value: any) => {
+  const updateFilter = (key: keyof EquipmentFilters, value: EquipmentFilters[keyof EquipmentFilters]) => {
     setFilters(prev => ({
       ...prev,
       [key]: value

--- a/src/hooks/useEquipmentForm.ts
+++ b/src/hooks/useEquipmentForm.ts
@@ -5,10 +5,10 @@ import { toast } from '@/hooks/use-toast';
 import { useCreateEquipment, useUpdateEquipment } from '@/hooks/useSupabaseData';
 import { usePermissions } from '@/hooks/usePermissions';
 import { useSimpleOrganization } from '@/contexts/SimpleOrganizationContext';
-import { equipmentFormSchema, type EquipmentFormData } from '@/types/equipment';
+import { equipmentFormSchema, type EquipmentFormData, type EquipmentRecord } from '@/types/equipment';
 
 interface UseEquipmentFormProps {
-  equipment?: any;
+  equipment?: EquipmentRecord;
   onClose: () => void;
 }
 

--- a/src/hooks/useFormValidation.ts
+++ b/src/hooks/useFormValidation.ts
@@ -12,7 +12,7 @@ export interface FormValidationHook<T> {
   errors: Record<string, string>;
   isValid: boolean;
   isSubmitting: boolean;
-  setValue: (field: keyof T, value: any) => void;
+  setValue: (field: keyof T, value: T[keyof T]) => void;
   setValues: (values: Partial<T>) => void;
   validate: () => ValidationResult;
   validateField: (field: keyof T) => boolean;
@@ -20,7 +20,7 @@ export interface FormValidationHook<T> {
   handleSubmit: (onSubmit: (values: T) => Promise<void> | void) => Promise<void>;
 }
 
-export const useFormValidation = <T extends Record<string, any>>(
+export const useFormValidation = <T extends Record<string, unknown>>(
   schema: ZodSchema<T>,
   initialValues: Partial<T> = {}
 ): FormValidationHook<T> => {
@@ -28,7 +28,7 @@ export const useFormValidation = <T extends Record<string, any>>(
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const setValue = useCallback((field: keyof T, value: any) => {
+  const setValue = useCallback((field: keyof T, value: T[keyof T]) => {
     setValuesState(prev => ({ ...prev, [field]: value }));
     // Clear field error when value changes
     if (errors[field as string]) {

--- a/src/hooks/useTeamManagement.ts
+++ b/src/hooks/useTeamManagement.ts
@@ -41,15 +41,15 @@ export const useTeamMutations = () => {
   const { toast } = useToast();
 
   const createTeamWithCreatorMutation = useMutation({
-    mutationFn: ({ teamData, creatorId }: { teamData: any; creatorId: string }) =>
+    mutationFn: ({ teamData, creatorId }: { teamData: Parameters<typeof createTeamWithCreator>[0]; creatorId: string }) =>
       createTeamWithCreator(teamData, creatorId),
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: ['teams', variables.teamData.organization_id] });
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       toast({
         title: "Error",
-        description: error.message || "Failed to create team",
+        description: error instanceof Error ? error.message : "Failed to create team",
         variant: "destructive"
       });
     }
@@ -65,10 +65,10 @@ export const useTeamMutations = () => {
         description: "Team deleted successfully",
       });
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       toast({
         title: "Error",
-        description: error.message || "Failed to delete team",
+        description: error instanceof Error ? error.message : "Failed to delete team",
         variant: "destructive"
       });
     }
@@ -104,10 +104,10 @@ export const useTeamMembers = (teamId: string | undefined, organizationId: strin
         description: "Team member added successfully",
       });
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       toast({
         title: "Error",
-        description: error.message || "Failed to add team member",
+        description: error instanceof Error ? error.message : "Failed to add team member",
         variant: "destructive"
       });
     }
@@ -126,10 +126,10 @@ export const useTeamMembers = (teamId: string | undefined, organizationId: strin
         description: "Team member removed successfully",
       });
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       toast({
         title: "Error",
-        description: error.message || "Failed to remove team member",
+        description: error instanceof Error ? error.message : "Failed to remove team member",
         variant: "destructive"
       });
     }
@@ -150,10 +150,10 @@ export const useTeamMembers = (teamId: string | undefined, organizationId: strin
         description: "Team member role updated successfully",
       });
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       toast({
         title: "Error",
-        description: error.message || "Failed to update team member role",
+        description: error instanceof Error ? error.message : "Failed to update team member role",
         variant: "destructive"
       });
     }

--- a/src/pages/Equipment.tsx
+++ b/src/pages/Equipment.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { useSimpleOrganization } from '@/contexts/SimpleOrganizationContext';
 import { usePermissions } from '@/hooks/usePermissions';
 import { useEquipmentFiltering } from '@/hooks/useEquipmentFiltering';
+import type { EquipmentRecord } from '@/types/equipment';
 
 import EquipmentForm from '@/components/equipment/EquipmentForm';
 import QRCodeDisplay from '@/components/equipment/QRCodeDisplay';
@@ -33,8 +34,8 @@ const Equipment = () => {
     setShowAdvancedFilters
   } = useEquipmentFiltering(currentOrganization?.id);
   
-  const [showForm, setShowForm] = useState(false);
-  const [editingEquipment, setEditingEquipment] = useState(null);
+  const [showForm, setShowForm] = useState<boolean>(false);
+  const [editingEquipment, setEditingEquipment] = useState<EquipmentRecord | null>(null);
   const [showQRCode, setShowQRCode] = useState<string | null>(null);
 
   const canCreate = canCreateEquipment();
@@ -61,7 +62,7 @@ const Equipment = () => {
     setShowForm(true);
   };
 
-  const handleEditEquipment = (equipment: any) => {
+  const handleEditEquipment = (equipment: EquipmentRecord) => {
     setEditingEquipment(equipment);
     setShowForm(true);
   };

--- a/src/services/EquipmentService.ts
+++ b/src/services/EquipmentService.ts
@@ -9,9 +9,9 @@ export interface EquipmentFilters extends FilterParams {
   model?: string;
 }
 
-export interface EquipmentCreateData extends Omit<Equipment, 'id'> {}
+export type EquipmentCreateData = Omit<Equipment, 'id'>;
 
-export interface EquipmentUpdateData extends Partial<Omit<Equipment, 'id'>> {}
+export type EquipmentUpdateData = Partial<Omit<Equipment, 'id'>>;
 
 export class EquipmentService extends BaseService {
   async getAll(

--- a/src/services/permissions/PermissionEngine.ts
+++ b/src/services/permissions/PermissionEngine.ts
@@ -1,7 +1,9 @@
 import { UserContext, PermissionRule, PermissionCache } from '@/types/permissions';
 
+type EntityContext = { teamId?: string; assigneeId?: string; [key: string]: unknown };
+
 export class PermissionEngine {
-  private rules: Map<string, PermissionRule[]> = new Map();
+  private rules: Map<string, PermissionRule<EntityContext>[]> = new Map();
   private cache: PermissionCache = {};
   private readonly CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 
@@ -163,7 +165,7 @@ export class PermissionEngine {
     });
   }
 
-  private addRule(permission: string, rule: PermissionRule) {
+  private addRule(permission: string, rule: PermissionRule<EntityContext>) {
     if (!this.rules.has(permission)) {
       this.rules.set(permission, []);
     }

--- a/src/types/equipment.ts
+++ b/src/types/equipment.ts
@@ -24,3 +24,27 @@ export const equipmentFormSchema = z.object({
 });
 
 export type EquipmentFormData = z.infer<typeof equipmentFormSchema>;
+
+// Strongly-typed Equipment record used across forms and pages (DB shape)
+export interface EquipmentRecord {
+  id: string;
+  name: string;
+  manufacturer: string;
+  model: string;
+  serial_number: string;
+  status: 'active' | 'maintenance' | 'inactive';
+  location: string;
+  installation_date: string;
+  warranty_expiration: string | null;
+  last_maintenance: string | null;
+  notes?: string | null;
+  custom_attributes?: Record<string, unknown>;
+  image_url?: string | null;
+  last_known_location?: unknown | null;
+  team_id?: string | null;
+  organization_id?: string;
+  created_at?: string;
+  updated_at?: string;
+  // Optional app-specific fields
+  working_hours?: number;
+}

--- a/src/types/permissions.ts
+++ b/src/types/permissions.ts
@@ -58,9 +58,9 @@ export interface EquipmentNotesPermissions {
   canSetDisplayImage: boolean;
 }
 
-export interface PermissionRule {
+export interface PermissionRule<E = unknown> {
   name: string;
-  check: (context: UserContext, entityContext?: any) => boolean;
+  check: (context: UserContext, entityContext?: E) => boolean;
   priority: number;
 }
 


### PR DESCRIPTION
Replace `any` types with specific interfaces and generics in components and hooks to enhance type safety and maintainability. This includes updating the `equipment` prop in `EquipmentForm.tsx` and ensuring `useState` calls have explicit generic types.