### PR TITLE
feat: Add tests for Teams page

### DIFF
--- a/src/pages/Teams.tsx
+++ b/src/pages/Teams.tsx
@@ -29,7 +29,7 @@ const Teams = () => {
 
   if (isLoading || teamsLoading || !currentOrganization) {
     return (
-      <div className="space-y-6">
+      <div className="space-y-6" data-testid="teams-loading">
         <div>
           <h1 className="text-3xl font-bold tracking-tight">Teams</h1>
           <p className="text-muted-foreground">Loading...</p>

--- a/src/pages/__tests__/Teams.test.tsx
+++ b/src/pages/__tests__/Teams.test.tsx
@@ -1,0 +1,506 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { BrowserRouter } from 'react-router-dom';
+import Teams from '../Teams';
+
+// Mock the TeamForm component
+vi.mock('@/components/teams/TeamForm', () => ({
+  default: ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) => 
+    isOpen ? (
+      <div data-testid="team-form-modal">
+        <button onClick={onClose}>Close Form</button>
+      </div>
+    ) : null
+}));
+
+// Mock react-router-dom navigate
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+// Mock all contexts and hooks
+vi.mock('@/contexts/OrganizationContext', () => ({
+  useOrganization: vi.fn()
+}));
+
+vi.mock('@/hooks/useTeamManagement', () => ({
+  useTeams: vi.fn(),
+  useTeamMutations: vi.fn()
+}));
+
+vi.mock('@/hooks/useUnifiedPermissions', () => ({
+  useUnifiedPermissions: vi.fn()
+}));
+
+// Import mocks after setting up the mocks
+import { useOrganization } from '@/contexts/OrganizationContext';
+import { useTeams, useTeamMutations } from '@/hooks/useTeamManagement';
+import { useUnifiedPermissions } from '@/hooks/useUnifiedPermissions';
+
+const mockUseOrganization = vi.mocked(useOrganization);
+const mockUseTeams = vi.mocked(useTeams);
+const mockUseTeamMutations = vi.mocked(useTeamMutations);
+const mockUseUnifiedPermissions = vi.mocked(useUnifiedPermissions);
+
+// Test data
+const mockOrganization = {
+  id: 'org-1',
+  name: 'Test Organization',
+  plan: 'premium' as const,
+  userRole: 'admin' as const,
+  memberCount: 5,
+  maxMembers: 10,
+  features: ['teams', 'equipment', 'workOrders'],
+  userStatus: 'active' as const
+};
+
+const mockTeamWithMembers = {
+  id: 'team-1',
+  name: 'Engineering Team',
+  description: 'Development and maintenance team',
+  organization_id: 'org-1',
+  member_count: 3,
+  members: [
+    {
+      id: 'member-1',
+      user_id: 'user-1',
+      team_id: 'team-1',
+      role: 'manager' as const,
+      joined_date: '2024-01-01',
+      profiles: {
+        name: 'John Doe',
+        email: 'john.doe@example.com'
+      }
+    },
+    {
+      id: 'member-2',
+      user_id: 'user-2',
+      team_id: 'team-1',
+      role: 'technician' as const,
+      joined_date: '2024-01-02',
+      profiles: {
+        name: 'Jane Smith',
+        email: 'jane.smith@example.com'
+      }
+    },
+    {
+      id: 'member-3',
+      user_id: 'user-3',
+      team_id: 'team-1',
+      role: 'requestor' as const,
+      joined_date: '2024-01-03',
+      profiles: {
+        name: null,
+        email: null
+      }
+    }
+  ]
+};
+
+const renderTeamsPage = () => {
+  return render(
+    <BrowserRouter>
+      <Teams />
+    </BrowserRouter>
+  );
+};
+
+describe('Teams Page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    
+    // Default mock implementations
+    mockUseOrganization.mockReturnValue({
+      currentOrganization: mockOrganization,
+      userOrganizations: [mockOrganization],
+      organizations: [mockOrganization],
+      isLoading: false,
+      error: null,
+      setCurrentOrganization: vi.fn(),
+      switchOrganization: vi.fn(),
+      refetch: vi.fn()
+    });
+
+    mockUseTeams.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn()
+    } as any);
+
+    mockUseTeamMutations.mockReturnValue({
+      createTeamWithCreator: { mutate: vi.fn(), isPending: false } as any,
+      deleteTeam: { mutate: vi.fn(), isPending: false } as any
+    } as any);
+
+    mockUseUnifiedPermissions.mockReturnValue({
+      userContext: { userId: 'user-1', organizationId: 'org-1' },
+      teams: {
+        getPermissions: vi.fn().mockReturnValue({
+          canView: true,
+          canEdit: false,
+          canDelete: false
+        }),
+        canCreateAny: true,
+        canViewAll: true,
+        canManageAny: false
+      },
+      hasPermission: vi.fn(),
+      hasRole: vi.fn(),
+      isTeamMember: vi.fn(),
+      isTeamManager: vi.fn(),
+      organization: {
+        canManage: true,
+        canInviteMembers: true,
+        canViewBilling: true,
+        canCreateTeams: true,
+        canManageMembers: true
+      },
+      equipment: {
+        getPermissions: vi.fn(),
+        canCreateAny: true,
+        canViewAll: true
+      },
+      workOrders: {
+        getPermissions: vi.fn(),
+        getDetailedPermissions: vi.fn(),
+        canCreateAny: true,
+        canViewAll: true,
+        canAssignAny: true
+      },
+      getEquipmentNotesPermissions: vi.fn(),
+      clearCache: vi.fn()
+    } as any);
+  });
+
+  describe('Core Rendering', () => {
+    it('displays loading state with skeleton cards', () => {
+      mockUseTeams.mockReturnValue({
+        data: [],
+        isLoading: true,
+        error: null,
+        refetch: vi.fn()
+      } as any);
+
+      renderTeamsPage();
+      
+      // Should show loading content when teams are loading
+      expect(screen.getByTestId('teams-loading')).toBeInTheDocument();
+    });
+
+    it('displays empty state when no teams exist', () => {
+      mockUseTeams.mockReturnValue({
+        data: [],
+        isLoading: false,
+        error: null,
+        refetch: vi.fn()
+      } as any);
+
+      renderTeamsPage();
+      
+      expect(screen.getByText('No teams found')).toBeInTheDocument();
+      expect(screen.getByText(/Get started by creating your first team/)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /create team/i })).toBeInTheDocument();
+    });
+
+    it('displays teams grid with proper team information', () => {
+      mockUseTeams.mockReturnValue({
+        data: [mockTeamWithMembers],
+        isLoading: false,
+        error: null,
+        refetch: vi.fn()
+      } as any);
+
+      renderTeamsPage();
+      
+      // Team information
+      expect(screen.getByText('Engineering Team')).toBeInTheDocument();
+      expect(screen.getByText('Development and maintenance team')).toBeInTheDocument();
+    });
+
+    it('displays team members with proper information', () => {
+      mockUseTeams.mockReturnValue({
+        data: [mockTeamWithMembers],
+        isLoading: false,
+        error: null,
+        refetch: vi.fn()
+      } as any);
+
+      renderTeamsPage();
+      
+      // Member names and emails
+      expect(screen.getByText('John Doe')).toBeInTheDocument();
+      expect(screen.getByText('john.doe@example.com')).toBeInTheDocument();
+      expect(screen.getByText('Jane Smith')).toBeInTheDocument();
+      expect(screen.getByText('jane.smith@example.com')).toBeInTheDocument();
+      
+      // Role badges
+      expect(screen.getByText('manager')).toBeInTheDocument();
+      expect(screen.getByText('technician')).toBeInTheDocument();
+    });
+  });
+
+  describe('User Interactions', () => {
+    it('opens team form modal when create button is clicked', () => {
+      mockUseTeams.mockReturnValue({
+        data: [],
+        isLoading: false,
+        error: null,
+        refetch: vi.fn()
+      } as any);
+
+      renderTeamsPage();
+      
+      const createButton = screen.getByRole('button', { name: /create team/i });
+      fireEvent.click(createButton);
+      
+      expect(screen.getByTestId('team-form-modal')).toBeInTheDocument();
+    });
+
+    it('navigates to team details when view details button is clicked', () => {
+      mockUseTeams.mockReturnValue({
+        data: [mockTeamWithMembers],
+        isLoading: false,
+        error: null,
+        refetch: vi.fn()
+      } as any);
+
+      renderTeamsPage();
+      
+      const viewDetailsButton = screen.getByRole('button', { name: /view details/i });
+      fireEvent.click(viewDetailsButton);
+      
+      expect(mockNavigate).toHaveBeenCalledWith('/teams/team-1');
+    });
+
+    it('shows delete confirmation dialog when delete button is clicked', async () => {
+      mockUseTeams.mockReturnValue({
+        data: [mockTeamWithMembers],
+        isLoading: false,
+        error: null,
+        refetch: vi.fn()
+      } as any);
+
+      // Mock permissions to allow deletion
+      mockUseUnifiedPermissions.mockReturnValue({
+        userContext: { userId: 'user-1', organizationId: 'org-1' },
+        teams: {
+          getPermissions: vi.fn().mockReturnValue({
+            canView: true,
+            canEdit: true,
+            canDelete: true
+          }),
+          canCreateAny: true,
+          canViewAll: true,
+          canManageAny: true
+        },
+        organization: {
+          canManage: true,
+          canInviteMembers: true,
+          canViewBilling: true,
+          canCreateTeams: true,
+          canManageMembers: true
+        },
+        equipment: {
+          getPermissions: vi.fn(),
+          canCreateAny: true,
+          canViewAll: true
+        },
+        workOrders: {
+          getPermissions: vi.fn(),
+          getDetailedPermissions: vi.fn(),
+          canCreateAny: true,
+          canViewAll: true,
+          canAssignAny: true
+        },
+        hasPermission: vi.fn(),
+        hasRole: vi.fn(),
+        isTeamMember: vi.fn(),
+        isTeamManager: vi.fn(),
+        getEquipmentNotesPermissions: vi.fn(),
+        clearCache: vi.fn()
+      } as any);
+
+      renderTeamsPage();
+      
+      const deleteButton = screen.getByRole('button', { name: /delete/i });
+      fireEvent.click(deleteButton);
+      
+      // Should show confirmation dialog
+      expect(screen.getByText(/are you sure you want to delete/i)).toBeInTheDocument();
+      expect(screen.getByText('Engineering Team')).toBeInTheDocument();
+    });
+  });
+
+  describe('Permission Integration', () => {
+    it('hides delete button when user lacks delete permission', () => {
+      mockUseTeams.mockReturnValue({
+        data: [mockTeamWithMembers],
+        isLoading: false,
+        error: null,
+        refetch: vi.fn()
+      } as any);
+
+      // Mock permissions to deny deletion
+      mockUseUnifiedPermissions.mockReturnValue({
+        userContext: { userId: 'user-1', organizationId: 'org-1' },
+        teams: {
+          getPermissions: vi.fn().mockReturnValue({
+            canView: true,
+            canEdit: false,
+            canDelete: false
+          }),
+          canCreateAny: true,
+          canViewAll: true,
+          canManageAny: false
+        },
+        organization: {
+          canManage: false,
+          canInviteMembers: false,
+          canViewBilling: false,
+          canCreateTeams: false,
+          canManageMembers: false
+        },
+        equipment: {
+          getPermissions: vi.fn(),
+          canCreateAny: true,
+          canViewAll: true
+        },
+        workOrders: {
+          getPermissions: vi.fn(),
+          getDetailedPermissions: vi.fn(),
+          canCreateAny: true,
+          canViewAll: true,
+          canAssignAny: true
+        },
+        hasPermission: vi.fn(),
+        hasRole: vi.fn(),
+        isTeamMember: vi.fn(),
+        isTeamManager: vi.fn(),
+        getEquipmentNotesPermissions: vi.fn(),
+        clearCache: vi.fn()
+      } as any);
+
+      renderTeamsPage();
+      
+      // Delete button should not be present
+      expect(screen.queryByRole('button', { name: /delete/i })).not.toBeInTheDocument();
+      
+      // View details button should still be present
+      expect(screen.getByRole('button', { name: /view details/i })).toBeInTheDocument();
+    });
+
+    it('shows delete button when user has delete permission', () => {
+      mockUseTeams.mockReturnValue({
+        data: [mockTeamWithMembers],
+        isLoading: false,
+        error: null,
+        refetch: vi.fn()
+      } as any);
+
+      // Mock permissions to allow deletion
+      mockUseUnifiedPermissions.mockReturnValue({
+        userContext: { userId: 'user-1', organizationId: 'org-1' },
+        teams: {
+          getPermissions: vi.fn().mockReturnValue({
+            canView: true,
+            canEdit: true,
+            canDelete: true
+          }),
+          canCreateAny: true,
+          canViewAll: true,
+          canManageAny: true
+        },
+        organization: {
+          canManage: true,
+          canInviteMembers: true,
+          canViewBilling: true,
+          canCreateTeams: true,
+          canManageMembers: true
+        },
+        equipment: {
+          getPermissions: vi.fn(),
+          canCreateAny: true,
+          canViewAll: true
+        },
+        workOrders: {
+          getPermissions: vi.fn(),
+          getDetailedPermissions: vi.fn(),
+          canCreateAny: true,
+          canViewAll: true,
+          canAssignAny: true
+        },
+        hasPermission: vi.fn(),
+        hasRole: vi.fn(),
+        isTeamMember: vi.fn(),
+        isTeamManager: vi.fn(),
+        getEquipmentNotesPermissions: vi.fn(),
+        clearCache: vi.fn()
+      } as any);
+
+      renderTeamsPage();
+      
+      // Delete button should be present
+      expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('Edge Cases & Error Handling', () => {
+    it('handles missing profile data with proper fallbacks', () => {
+      mockUseTeams.mockReturnValue({
+        data: [mockTeamWithMembers],
+        isLoading: false,
+        error: null,
+        refetch: vi.fn()
+      } as any);
+
+      renderTeamsPage();
+      
+      // Member with missing profile data should show fallbacks
+      expect(screen.getByText('Unknown User')).toBeInTheDocument();
+      expect(screen.getByText('No email')).toBeInTheDocument();
+    });
+
+    it('handles organization loading state', () => {
+      mockUseOrganization.mockReturnValue({
+        currentOrganization: null,
+        userOrganizations: [],
+        organizations: [],
+        isLoading: true,
+        error: null,
+        setCurrentOrganization: vi.fn(),
+        switchOrganization: vi.fn(),
+        refetch: vi.fn()
+      } as any);
+
+      renderTeamsPage();
+      
+      // Should show loading when organization is loading
+      expect(screen.getByTestId('teams-loading')).toBeInTheDocument();
+    });
+
+    it('handles no organization selected', () => {
+      mockUseOrganization.mockReturnValue({
+        currentOrganization: null,
+        userOrganizations: [],
+        organizations: [],
+        isLoading: false,
+        error: null,
+        setCurrentOrganization: vi.fn(),
+        switchOrganization: vi.fn(),
+        refetch: vi.fn()
+      } as any);
+
+      renderTeamsPage();
+      
+      // Should show loading when no organization is selected
+      expect(screen.getByTestId('teams-loading')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Adds comprehensive tests for the Teams page, covering core rendering, user interactions, and permission-based functionality. This includes testing member display, the visibility of the delete button based on user permissions, and handling of missing user profile data.