### PR TITLE
Fix: Restrict team creation by role

### DIFF
--- a/src/components/teams/TeamForm.tsx
+++ b/src/components/teams/TeamForm.tsx
@@ -19,11 +19,12 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTeamMutations } from '@/hooks/useTeamManagement';
 import { useAuth } from '@/contexts/AuthContext';
 import { useUnifiedPermissions } from '@/hooks/useUnifiedPermissions';
+import type { TeamWithMembers } from '@/services/teamService';
 
 interface TeamFormProps {
   open: boolean;
   onClose: () => void;
-  team?: any;
+  team?: TeamWithMembers;
 }
 
 const TeamForm: React.FC<TeamFormProps> = ({ open, onClose, team }) => {
@@ -43,8 +44,13 @@ const TeamForm: React.FC<TeamFormProps> = ({ open, onClose, team }) => {
 
   const [isSubmitting, setIsSubmitting] = useState(false);
 
+  type TeamUpdatePayload = {
+    name?: string;
+    description?: string | null;
+  };
+
   const updateTeamMutation = useMutation({
-    mutationFn: ({ id, updates }: { id: string; updates: any }) => updateTeam(id, updates),
+    mutationFn: ({ id, updates }: { id: string; updates: TeamUpdatePayload }) => updateTeam(id, updates),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['teams', currentOrganization?.id] });
       queryClient.invalidateQueries({ queryKey: ['team', team?.id] });
@@ -54,10 +60,11 @@ const TeamForm: React.FC<TeamFormProps> = ({ open, onClose, team }) => {
       });
       onClose();
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
+      const message = error instanceof Error ? error.message : 'Failed to update team';
       toast({
         title: "Error",
-        description: error.message || "Failed to update team",
+        description: message,
         variant: "destructive"
       });
     }

--- a/src/pages/Teams.tsx
+++ b/src/pages/Teams.tsx
@@ -26,6 +26,7 @@ const Teams = () => {
   
   // Check permissions
   const permissions = useUnifiedPermissions();
+  const canCreateTeams = permissions.organization.canCreateTeams;
 
   if (isLoading || teamsLoading || !currentOrganization) {
     return (
@@ -103,10 +104,12 @@ const Teams = () => {
             Manage teams for {currentOrganization.name}
           </p>
         </div>
-        <Button onClick={() => setShowForm(true)} className="flex items-center gap-2" data-testid="header-create-team-button">
-          <Plus className="h-4 w-4" />
-          Create Team
-        </Button>
+        {teams.length > 0 && canCreateTeams && (
+          <Button onClick={() => setShowForm(true)} className="flex items-center gap-2" data-testid="header-create-team-button">
+            <Plus className="h-4 w-4" />
+            Create Team
+          </Button>
+        )}
       </div>
 
       {/* Teams Grid */}
@@ -208,7 +211,7 @@ const Teams = () => {
       </div>
 
       {/* Empty State */}
-      {teams.length === 0 && (
+      {teams.length === 0 && canCreateTeams && (
         <Card>
           <CardContent className="text-center py-12">
             <Users className="h-12 w-12 text-muted-foreground mx-auto mb-4" />

--- a/src/pages/__tests__/Teams.test.tsx
+++ b/src/pages/__tests__/Teams.test.tsx
@@ -265,7 +265,7 @@ describe('Teams Page', () => {
 
       renderTeamsPage();
       
-      const createButton = screen.getByTestId('header-create-team-button');
+      const createButton = screen.getByTestId('empty-state-create-team-button');
       fireEvent.click(createButton);
       
       expect(screen.getByTestId('team-form-modal')).toBeInTheDocument();


### PR DESCRIPTION
Implement permission checks to ensure only organization admins can create teams. The "Create Team" button will now be conditionally rendered based on user permissions, preventing non-admins from accessing the team creation functionality. This aligns with the backend's existing role-based access control for team creation.

addresses #131 