### PR TITLE
Fix organization context synchronization

### DIFF
--- a/src/contexts/SimpleOrganizationContext.tsx
+++ b/src/contexts/SimpleOrganizationContext.tsx
@@ -3,6 +3,7 @@ import React, { createContext, useContext, useState, useEffect, useCallback } fr
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from './AuthContext';
+import { useSession } from './SessionContext';
 
 export interface SimpleOrganization {
   id: string;
@@ -45,6 +46,9 @@ export const useSimpleOrganization = () => {
 export const SimpleOrganizationProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { user } = useAuth();
   const [currentOrganizationId, setCurrentOrganizationId] = useState<string | null>(null);
+  
+  // Get session context to keep them synchronized
+  const sessionContext = useSession();
 
   // Initialize from localStorage
   useEffect(() => {
@@ -170,7 +174,9 @@ export const SimpleOrganizationProvider: React.FC<{ children: React.ReactNode }>
 
   const switchOrganization = useCallback((organizationId: string) => {
     setCurrentOrganization(organizationId);
-  }, [setCurrentOrganization]);
+    // Also update session context to keep them synchronized
+    sessionContext.switchOrganization(organizationId);
+  }, [setCurrentOrganization, sessionContext]);
 
   const currentOrganization = currentOrganizationId 
     ? organizations.find(org => org.id === currentOrganizationId) || null

--- a/src/pages/Teams.tsx
+++ b/src/pages/Teams.tsx
@@ -7,13 +7,14 @@ import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
 import { Plus, Users, Settings, Crown, User, Trash2 } from 'lucide-react';
-import { useOrganization } from '@/contexts/OrganizationContext';
+import { useSession } from '@/contexts/SessionContext';
 import { useTeams, useTeamMutations } from '@/hooks/useTeamManagement';
 import { useUnifiedPermissions } from '@/hooks/useUnifiedPermissions';
 import TeamForm from '@/components/teams/TeamForm';
 
 const Teams = () => {
-  const { currentOrganization, isLoading } = useOrganization();
+  const { getCurrentOrganization, isLoading } = useSession();
+  const currentOrganization = getCurrentOrganization();
   const [showForm, setShowForm] = useState(false);
   const [deleteTeamId, setDeleteTeamId] = useState<string | null>(null);
   const navigate = useNavigate();


### PR DESCRIPTION
Synchronize organization contexts to ensure consistent permission checks across the application. Update the Teams page to use the session context for organization data, aligning it with the permissions system. This resolves issues where users could not create teams after switching organizations.