### PR TITLE
Standardize equipment property naming

### DIFF
--- a/src/components/equipment/EquipmentCard.tsx
+++ b/src/components/equipment/EquipmentCard.tsx
@@ -12,10 +12,10 @@ interface Equipment {
   name: string;
   manufacturer: string;
   model: string;
-  serialNumber: string;
+  serial_number: string;
   status: string;
   location: string;
-  lastMaintenance?: string;
+  last_maintenance?: string;
   image_url?: string;
 }
 
@@ -68,17 +68,17 @@ const EquipmentCard: React.FC<EquipmentCardProps> = ({
         <div className="space-y-2 text-sm">
           <div className="flex items-center gap-2">
             <span className="font-medium">Serial:</span>
-            <span className="text-muted-foreground">{equipment.serialNumber}</span>
+            <span className="text-muted-foreground">{equipment.serial_number}</span>
           </div>
           <div className="flex items-center gap-2">
             <MapPin className="h-4 w-4 text-muted-foreground" />
             <span className="text-muted-foreground">{equipment.location}</span>
           </div>
-          {equipment.lastMaintenance && (
+          {equipment.last_maintenance && (
             <div className="flex items-center gap-2">
               <Calendar className="h-4 w-4 text-muted-foreground" />
               <span className="text-muted-foreground">
-                Last maintenance: {new Date(equipment.lastMaintenance).toLocaleDateString()}
+                Last maintenance: {new Date(equipment.last_maintenance).toLocaleDateString()}
               </span>
             </div>
           )}

--- a/src/components/equipment/EquipmentGrid.tsx
+++ b/src/components/equipment/EquipmentGrid.tsx
@@ -9,10 +9,10 @@ interface Equipment {
   name: string;
   manufacturer: string;
   model: string;
-  serialNumber: string;
+  serial_number: string;
   status: string;
   location: string;
-  lastMaintenance?: string;
+  last_maintenance?: string;
   image_url?: string;
 }
 

--- a/src/services/EquipmentService.ts
+++ b/src/services/EquipmentService.ts
@@ -39,12 +39,12 @@ export class EquipmentService extends BaseService {
         name: 'Mock Equipment',
         manufacturer: 'Mock Manufacturer',
         model: 'Mock Model',
-        serialNumber: 'MOCK-001',
+        serial_number: 'MOCK-001',
         status: 'active',
         location: 'Mock Location',
-        installationDate: new Date().toISOString(),
-        warrantyExpiration: new Date().toISOString(),
-        lastMaintenance: new Date().toISOString(),
+        installation_date: new Date().toISOString(),
+        warranty_expiration: new Date().toISOString(),
+        last_maintenance: new Date().toISOString(),
       };
       return this.handleSuccess(mockEquipment);
     } catch (error) {
@@ -73,12 +73,12 @@ export class EquipmentService extends BaseService {
         name: data.name || 'Updated Equipment',
         manufacturer: data.manufacturer || 'Updated Manufacturer',
         model: data.model || 'Updated Model',
-        serialNumber: data.serialNumber || 'UPD-001',
+        serial_number: data.serial_number || 'UPD-001',
         status: data.status || 'active',
         location: data.location || 'Updated Location',
-        installationDate: data.installationDate || new Date().toISOString(),
-        warrantyExpiration: data.warrantyExpiration || new Date().toISOString(),
-        lastMaintenance: data.lastMaintenance || new Date().toISOString(),
+        installation_date: data.installation_date || new Date().toISOString(),
+        warranty_expiration: data.warranty_expiration || new Date().toISOString(),
+        last_maintenance: data.last_maintenance || new Date().toISOString(),
         notes: data.notes
       };
       return this.handleSuccess(updated);

--- a/src/services/syncDataService.ts
+++ b/src/services/syncDataService.ts
@@ -7,14 +7,14 @@ export interface Equipment {
   name: string;
   manufacturer: string;
   model: string;
-  serialNumber: string;
+  serial_number: string;
   status: 'active' | 'maintenance' | 'inactive';
   location: string;
-  installationDate: string;
-  warrantyExpiration: string;
-  lastMaintenance: string;
+  installation_date: string;
+  warranty_expiration: string;
+  last_maintenance: string;
   notes?: string;
-  imageUrl?: string;
+  image_url?: string;
 }
 
 export interface WorkOrder {

--- a/src/services/teamBasedEquipmentService.ts
+++ b/src/services/teamBasedEquipmentService.ts
@@ -6,12 +6,12 @@ export interface TeamAccessibleEquipment {
   name: string;
   manufacturer: string;
   model: string;
-  serialNumber: string;
+  serial_number: string;
   status: 'active' | 'maintenance' | 'inactive';
   location: string;
-  organizationId: string;
-  teamId: string | null;
-  teamName?: string;
+  organization_id: string;
+  team_id: string | null;
+  team_name?: string;
 }
 
 // Get equipment that a user can access based on their team memberships and role
@@ -70,12 +70,12 @@ export const getTeamAccessibleEquipment = async (
       name: equipment.name,
       manufacturer: equipment.manufacturer,
       model: equipment.model,
-      serialNumber: equipment.serial_number,
+      serial_number: equipment.serial_number,
       status: equipment.status,
       location: equipment.location,
-      organizationId: equipment.organization_id,
-      teamId: equipment.team_id,
-      teamName: equipment.teams?.name
+      organization_id: equipment.organization_id,
+      team_id: equipment.team_id,
+      team_name: equipment.teams?.name
     }));
   } catch (error) {
     console.error('💥 Error in getTeamAccessibleEquipment:', error);

--- a/src/utils/equipmentHelpers.ts
+++ b/src/utils/equipmentHelpers.ts
@@ -3,10 +3,10 @@ interface Equipment {
   name: string;
   manufacturer: string;
   model: string;
-  serialNumber: string;
+  serial_number: string;
   status: string;
   location: string;
-  lastMaintenance?: string;
+  last_maintenance?: string;
   image_url?: string;
 }
 
@@ -32,7 +32,7 @@ export const filterEquipment = (
     const matchesSearch = item.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
                          item.manufacturer.toLowerCase().includes(searchQuery.toLowerCase()) ||
                          item.model.toLowerCase().includes(searchQuery.toLowerCase()) ||
-                         item.serialNumber.toLowerCase().includes(searchQuery.toLowerCase());
+                         item.serial_number.toLowerCase().includes(searchQuery.toLowerCase());
     const matchesStatus = statusFilter === 'all' || item.status === statusFilter;
     return matchesSearch && matchesStatus;
   });


### PR DESCRIPTION
Implement plan to standardize equipment property naming to snake_case. This involves updating interfaces, removing transformations, and verifying changes across components and services.

fixes #107 