### PR TITLE
Fix: Update free organization detection logic

### DIFF
--- a/src/utils/simplifiedOrganizationRestrictions.ts
+++ b/src/utils/simplifiedOrganizationRestrictions.ts
@@ -18,7 +18,8 @@ export const getSimplifiedOrganizationRestrictions = (
   fleetMapEnabled: boolean = false
 ): SimplifiedOrganizationRestrictions => {
   const activeMemberCount = members.filter(member => member.status === 'active').length;
-  const isFree = activeMemberCount === 1 && slotAvailability.total_purchased === 0;
+  // Organization is free only if it has a single user AND no available slots (neither purchased nor exempted)
+  const isFree = activeMemberCount === 1 && slotAvailability.available_slots === 0;
   
   // For free organizations (single user, no purchased slots)
   if (isFree) {


### PR DESCRIPTION
The `isFree` logic in `simplifiedOrganizationRestrictions.ts` was updated to correctly account for exempted slots when determining if an organization is free. Previously, it only checked if `total_purchased` was 0, which incorrectly flagged organizations with exemptions as free. The change modifies the condition to check `available_slots === 0`, ensuring that organizations with billing exemptions are not mistakenly identified as free and that member invitation functionality is correctly enabled when slots are available through exemptions.