### PR TITLE
Refactor signOut to use Supabase auth

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -107,56 +107,17 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   const signOut = async () => {
     try {
-      // First, validate that we have a session to sign out
-      if (!session) {
-        // No active session found, performing client-side cleanup only
-        // Clear any potential stale local storage
-        localStorage.removeItem('sb-ymxkzronkhwxzcdcbnwq-auth-token');
-        return;
-      }
-
-      // Attempting to sign out with session
-      
-      // Attempt server-side logout
+      // Let Supabase handle all auth storage cleanup
       const { error } = await supabase.auth.signOut();
       
       if (error) {
         console.warn('Server-side logout failed:', error);
-        
-        // Handle specific error cases
-        if (error.message?.includes('Session not found') || error.message?.includes('session_not_found')) {
-          // Session already expired on server, performing client-side cleanup
-          // Session is already invalid on server, just clean up locally
-        } else {
-          // For other errors, we still want to clean up locally but log the error
-          console.error('Unexpected logout error:', error);
-        }
-      } else {
-        // Server-side logout successful
+        // Continue with cleanup even if server logout fails
       }
     } catch (error) {
       console.error('Exception during logout:', error);
     } finally {
-      // Always perform client-side cleanup regardless of server response
-      // Performing client-side cleanup
-      
-      // Clear local storage manually as fallback
-      try {
-        localStorage.removeItem('sb-ymxkzronkhwxzcdcbnwq-auth-token');
-        // Also clear any other potential auth-related items
-        const keysToRemove = [];
-        for (let i = 0; i < localStorage.length; i++) {
-          const key = localStorage.key(i);
-          if (key && key.startsWith('sb-ymxkzronkhwxzcdcbnwq-auth')) {
-            keysToRemove.push(key);
-          }
-        }
-        keysToRemove.forEach(key => localStorage.removeItem(key));
-      } catch (storageError) {
-        console.warn('Error clearing localStorage:', storageError);
-      }
-      
-      // Clear session storage items
+      // Clear application-specific session storage
       try {
         sessionStorage.removeItem('pendingRedirect');
       } catch (sessionError) {


### PR DESCRIPTION
Remove hard-coded Supabase project references from the signOut function in AuthContext.tsx. Rely on supabase.auth.signOut() for Supabase auth storage cleanup and keep only application-specific cleanup. This improves maintainability and portability by removing hard-coded project IDs.