### PR TITLE
Add delete button to mobile header

### DIFF
--- a/src/components/equipment/MobileEquipmentHeader.tsx
+++ b/src/components/equipment/MobileEquipmentHeader.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { ArrowLeft, QrCode, MapPin, Calendar } from 'lucide-react';
+import { ArrowLeft, QrCode, MapPin, Calendar, Trash2 } from 'lucide-react';
 import { Tables } from '@/integrations/supabase/types';
 
 type Equipment = Tables<'equipment'>;
@@ -10,11 +10,15 @@ type Equipment = Tables<'equipment'>;
 interface MobileEquipmentHeaderProps {
   equipment: Equipment;
   onShowQRCode: () => void;
+  canDelete?: boolean;
+  onDelete?: () => void;
 }
 
 const MobileEquipmentHeader: React.FC<MobileEquipmentHeaderProps> = ({
   equipment,
   onShowQRCode,
+  canDelete = false,
+  onDelete,
 }) => {
   const navigate = useNavigate();
 
@@ -44,9 +48,16 @@ const MobileEquipmentHeader: React.FC<MobileEquipmentHeaderProps> = ({
           <ArrowLeft className="h-4 w-4" />
           Back
         </Button>
-        <Button size="sm" onClick={onShowQRCode}>
-          <QrCode className="h-4 w-4" />
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button size="sm" onClick={onShowQRCode}>
+            <QrCode className="h-4 w-4" />
+          </Button>
+          {canDelete && onDelete && (
+            <Button size="sm" variant="destructive" onClick={onDelete}>
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
       </div>
 
       {/* Equipment Title and Status */}

--- a/src/pages/EquipmentDetails.tsx
+++ b/src/pages/EquipmentDetails.tsx
@@ -230,6 +230,8 @@ const EquipmentDetails = () => {
           <MobileEquipmentHeader 
             equipment={equipment}
             onShowQRCode={handleShowQRCode}
+            canDelete={isAdmin}
+            onDelete={handleDeleteEquipment}
           />
         </div>
       ) : (


### PR DESCRIPTION
Add a delete button to the mobile header for admins. The button will be a destructive trash icon, placed next to the QR code button. This change ensures that admins can initiate equipment deletion directly from the mobile view.