### PR TITLE
chore: use shared logger in services

### DIFF
--- a/src/services/backgroundSync.ts
+++ b/src/services/backgroundSync.ts
@@ -1,3 +1,4 @@
+import { logger } from '../utils/logger';
 import { supabase } from '@/integrations/supabase/client';
 import type { RealtimeChannel } from '@supabase/supabase-js';
 import { cacheManager } from './cacheManager';
@@ -232,7 +233,7 @@ export class BackgroundSyncService {
 
   private handleReconnection(organizationId: string) {
     if (this.reconnectAttempts >= this.maxReconnectAttempts) {
-      console.error(`Max reconnection attempts reached for org ${organizationId}`);
+      logger.error(`Max reconnection attempts reached for org ${organizationId}`);
       return;
     }
 
@@ -274,7 +275,7 @@ export class BackgroundSyncService {
       try {
         await Promise.all(batch.map(item => this.processSyncItem(item)));
       } catch (error) {
-        console.error('Error processing sync batch:', error);
+        logger.error('Error processing sync batch:', error);
         // Re-queue failed items
         this.syncQueue.unshift(...batch);
         break;
@@ -308,7 +309,7 @@ export class BackgroundSyncService {
         // Sync critical data that might have been missed
         await this.syncCriticalData(organizationId);
       } catch (error) {
-        console.error('Periodic sync error:', error);
+        logger.error('Periodic sync error:', error);
       }
     }, intervalMs);
 

--- a/src/services/base/BaseService.ts
+++ b/src/services/base/BaseService.ts
@@ -1,3 +1,4 @@
+import { logger } from '../../utils/logger';
 
 export interface ApiResponse<T> {
   data: T | null;
@@ -24,7 +25,7 @@ export abstract class BaseService {
   }
 
   protected handleError(error: any): ApiResponse<null> {
-    console.error('Service error:', error);
+    logger.error('Service error:', error);
     return {
       data: null,
       error: error instanceof Error ? error.message : 'Operation failed',

--- a/src/services/deleteWorkOrderService.ts
+++ b/src/services/deleteWorkOrderService.ts
@@ -1,3 +1,4 @@
+import { logger } from '../utils/logger';
 import { supabase } from '@/integrations/supabase/client';
 
 export interface WorkOrderImageCount {
@@ -23,7 +24,7 @@ export const getWorkOrderImageCount = async (workOrderId: string): Promise<WorkO
       images: data || []
     };
   } catch (error) {
-    console.error('Error fetching work order image count:', error);
+    logger.error('Error fetching work order image count:', error);
     throw error;
   }
 };
@@ -48,7 +49,7 @@ export const deleteWorkOrderCascade = async (workOrderId: string): Promise<void>
         .remove(filePaths);
 
       if (storageError) {
-        console.warn('Some storage files could not be deleted:', storageError);
+        logger.warn('Some storage files could not be deleted:', storageError);
         // Continue with database deletion even if storage cleanup fails
       }
     }
@@ -102,7 +103,7 @@ export const deleteWorkOrderCascade = async (workOrderId: string): Promise<void>
     if (workOrderError) throw workOrderError;
 
   } catch (error) {
-    console.error('Error deleting work order:', error);
+    logger.error('Error deleting work order:', error);
     throw error;
   }
 };

--- a/src/services/equipmentImagesService.ts
+++ b/src/services/equipmentImagesService.ts
@@ -1,3 +1,4 @@
+import { logger } from '../utils/logger';
 import { supabase } from '@/integrations/supabase/client';
 import { getEquipmentImages } from './equipmentNotesService';
 import { getWorkOrderImages } from './workOrderNotesService';
@@ -95,7 +96,7 @@ export const getAllEquipmentImages = async (
     );
 
   } catch (error) {
-    console.error('Error fetching equipment images:', error);
+    logger.error('Error fetching equipment images:', error);
     return [];
   }
 };

--- a/src/services/equipmentNotesService.ts
+++ b/src/services/equipmentNotesService.ts
@@ -1,3 +1,4 @@
+import { logger } from '../utils/logger';
 
 import { supabase } from '@/integrations/supabase/client';
 
@@ -102,7 +103,7 @@ export const createEquipmentNoteWithImages = async (
         .upload(fileName, file);
 
       if (uploadError) {
-        console.error('Failed to upload image:', uploadError);
+        logger.error('Failed to upload image:', uploadError);
         continue;
       }
 
@@ -126,13 +127,13 @@ export const createEquipmentNoteWithImages = async (
         .single();
 
       if (imageError) {
-        console.error('Failed to save image record:', imageError);
+        logger.error('Failed to save image record:', imageError);
         continue;
       }
 
       uploadedImages.push(imageRecord);
     } catch (error) {
-      console.error('Error processing image:', error);
+      logger.error('Error processing image:', error);
     }
   }
 

--- a/src/services/equipmentOrganizationService.ts
+++ b/src/services/equipmentOrganizationService.ts
@@ -1,3 +1,4 @@
+import { logger } from '../utils/logger';
 import { supabase } from '@/integrations/supabase/client';
 
 export interface EquipmentOrganizationInfo {
@@ -13,7 +14,7 @@ export interface EquipmentOrganizationInfo {
  */
 export const getEquipmentOrganization = async (equipmentId: string): Promise<EquipmentOrganizationInfo | null> => {
   try {
-    console.log('🔍 Fetching equipment organization for:', equipmentId);
+    logger.info('🔍 Fetching equipment organization for:', equipmentId);
     
     // Get equipment with organization info
     const { data: equipment, error: equipmentError } = await supabase
@@ -30,19 +31,19 @@ export const getEquipmentOrganization = async (equipmentId: string): Promise<Equ
       .single();
 
     if (equipmentError) {
-      console.error('❌ Error fetching equipment:', equipmentError);
+      logger.error('❌ Error fetching equipment:', equipmentError);
       return null;
     }
 
     if (!equipment) {
-      console.log('⚠️ Equipment not found:', equipmentId);
+      logger.info('⚠️ Equipment not found:', equipmentId);
       return null;
     }
 
     // Check if current user has access to this organization
     const { data: { user } } = await supabase.auth.getUser();
     if (!user) {
-      console.log('❌ No authenticated user');
+      logger.info('❌ No authenticated user');
       return null;
     }
 
@@ -55,7 +56,7 @@ export const getEquipmentOrganization = async (equipmentId: string): Promise<Equ
       .maybeSingle();
 
     if (membershipError) {
-      console.error('❌ Error checking organization membership:', membershipError);
+      logger.error('❌ Error checking organization membership:', membershipError);
     }
 
     const result: EquipmentOrganizationInfo = {
@@ -66,11 +67,11 @@ export const getEquipmentOrganization = async (equipmentId: string): Promise<Equ
       userRole: membership?.role
     };
 
-    console.log('✅ Equipment organization info:', result);
+    logger.info('✅ Equipment organization info:', result);
     return result;
 
   } catch (error) {
-    console.error('❌ Unexpected error in getEquipmentOrganization:', error);
+    logger.error('❌ Unexpected error in getEquipmentOrganization:', error);
     return null;
   }
 };
@@ -86,13 +87,13 @@ export const checkUserHasMultipleOrganizations = async (): Promise<boolean> => {
       .eq('status', 'active');
 
     if (error) {
-      console.error('❌ Error checking user organizations:', error);
+      logger.error('❌ Error checking user organizations:', error);
       return false;
     }
 
     return (memberships?.length || 0) > 1;
   } catch (error) {
-    console.error('❌ Unexpected error checking multiple organizations:', error);
+    logger.error('❌ Unexpected error checking multiple organizations:', error);
     return false;
   }
 };

--- a/src/services/equipmentTemplateService.ts
+++ b/src/services/equipmentTemplateService.ts
@@ -1,3 +1,4 @@
+import { logger } from '../utils/logger';
 import { supabase } from '@/integrations/supabase/client';
 
 export interface EquipmentTemplateAssignment {
@@ -46,7 +47,7 @@ export class EquipmentTemplateService {
         await this.assignTemplateToEquipment(equipmentId, templateId);
         successCount++;
       } catch (error) {
-        console.error(`Failed to assign template to equipment ${equipmentId}:`, error);
+        logger.error(`Failed to assign template to equipment ${equipmentId}:`, error);
         errorCount++;
       }
     }
@@ -66,7 +67,7 @@ export class EquipmentTemplateService {
         await this.removeTemplateFromEquipment(equipmentId);
         successCount++;
       } catch (error) {
-        console.error(`Failed to remove template from equipment ${equipmentId}:`, error);
+        logger.error(`Failed to remove template from equipment ${equipmentId}:`, error);
         errorCount++;
       }
     }

--- a/src/services/equipmentWorkingHoursService.ts
+++ b/src/services/equipmentWorkingHoursService.ts
@@ -1,3 +1,4 @@
+import { logger } from '../utils/logger';
 import { supabase } from '@/integrations/supabase/client';
 
 export interface WorkingHoursHistoryEntry {
@@ -32,7 +33,7 @@ export const updateEquipmentWorkingHours = async (data: UpdateWorkingHoursData) 
   });
 
   if (error) {
-    console.error('Error updating equipment working hours:', error);
+    logger.error('Error updating equipment working hours:', error);
     throw error;
   }
 
@@ -62,7 +63,7 @@ export const getEquipmentWorkingHoursHistory = async (
     .eq('equipment_id', equipmentId);
 
   if (countError) {
-    console.error('Error fetching working hours history count:', countError);
+    logger.error('Error fetching working hours history count:', countError);
     throw countError;
   }
 
@@ -75,7 +76,7 @@ export const getEquipmentWorkingHoursHistory = async (
     .range(from, to);
 
   if (error) {
-    console.error('Error fetching working hours history:', error);
+    logger.error('Error fetching working hours history:', error);
     throw error;
   }
 
@@ -99,7 +100,7 @@ export const getEquipmentCurrentWorkingHours = async (equipmentId: string): Prom
     .single();
 
   if (error) {
-    console.error('Error fetching current working hours:', error);
+    logger.error('Error fetching current working hours:', error);
     throw error;
   }
 

--- a/src/services/optimizedEquipmentNotesService.ts
+++ b/src/services/optimizedEquipmentNotesService.ts
@@ -1,3 +1,4 @@
+import { logger } from '../utils/logger';
 import { supabase } from '@/integrations/supabase/client';
 
 export interface OptimizedEquipmentNote {
@@ -44,7 +45,7 @@ export const getEquipmentNotesOptimized = async (equipmentId: string): Promise<O
       last_modified_by: note.last_modified_by
     }));
   } catch (error) {
-    console.error('Error fetching equipment notes:', error);
+    logger.error('Error fetching equipment notes:', error);
     return [];
   }
 };
@@ -80,7 +81,7 @@ export const getUserEquipmentNotes = async (equipmentId: string, userId: string)
       last_modified_by: note.last_modified_by
     }));
   } catch (error) {
-    console.error('Error fetching user equipment notes:', error);
+    logger.error('Error fetching user equipment notes:', error);
     return [];
   }
 };
@@ -122,7 +123,7 @@ export const getRecentOrganizationNotes = async (organizationId: string, limit: 
       last_modified_by: note.last_modified_by
     }));
   } catch (error) {
-    console.error('Error fetching recent organization notes:', error);
+    logger.error('Error fetching recent organization notes:', error);
     return [];
   }
 };

--- a/src/services/optimizedOrganizationService.ts
+++ b/src/services/optimizedOrganizationService.ts
@@ -1,3 +1,4 @@
+import { logger } from '../utils/logger';
 import { supabase } from '@/integrations/supabase/client';
 
 export interface OptimizedOrganizationMember {
@@ -50,7 +51,7 @@ export const getUserOrganizationsOptimized = async (userId: string): Promise<any
       joined_date: om.joined_date
     }));
   } catch (error) {
-    console.error('Error fetching user organizations:', error);
+    logger.error('Error fetching user organizations:', error);
     return [];
   }
 };
@@ -86,7 +87,7 @@ export const getOrganizationMembersOptimized = async (organizationId: string): P
       activated_slot_at: member.activated_slot_at
     }));
   } catch (error) {
-    console.error('Error fetching organization members:', error);
+    logger.error('Error fetching organization members:', error);
     return [];
   }
 };
@@ -123,7 +124,7 @@ export const getOrganizationAdminsOptimized = async (organizationId: string): Pr
       activated_slot_at: member.activated_slot_at
     }));
   } catch (error) {
-    console.error('Error fetching organization admins:', error);
+    logger.error('Error fetching organization admins:', error);
     return [];
   }
 };
@@ -146,7 +147,7 @@ export const checkUserOrgAccess = async (userId: string, organizationId: string)
       role: data?.role
     };
   } catch (error) {
-    console.error('Error checking user organization access:', error);
+    logger.error('Error checking user organization access:', error);
     return { hasAccess: false };
   }
 };
@@ -165,7 +166,7 @@ export const updateOrganization = async (organizationId: string, updates: { name
     if (error) throw error;
     return true;
   } catch (error) {
-    console.error('Error updating organization:', error);
+    logger.error('Error updating organization:', error);
     return false;
   }
 };
@@ -182,7 +183,7 @@ export const getOrganizationById = async (organizationId: string) => {
     if (error) throw error;
     return data;
   } catch (error) {
-    console.error('Error fetching organization:', error);
+    logger.error('Error fetching organization:', error);
     return null;
   }
 };

--- a/src/services/optimizedOrganizationStorageService.ts
+++ b/src/services/optimizedOrganizationStorageService.ts
@@ -1,3 +1,4 @@
+import { logger } from '../utils/logger';
 import { supabase } from '@/integrations/supabase/client';
 import { monitorQuery } from '@/utils/queryMonitoring';
 
@@ -131,7 +132,7 @@ export class OptimizedOrganizationStorageService {
       };
 
     } catch (error) {
-      console.error('Error fetching organization storage usage:', error);
+      logger.error('Error fetching organization storage usage:', error);
       throw new Error(`Failed to fetch storage usage: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
   }

--- a/src/services/optimizedSupabaseDataService.ts
+++ b/src/services/optimizedSupabaseDataService.ts
@@ -1,3 +1,4 @@
+import { logger } from '../utils/logger';
 import { supabase } from '@/integrations/supabase/client';
 import { Tables } from '@/integrations/supabase/types';
 
@@ -54,7 +55,7 @@ export const getOptimizedTeamsByOrganization = async (organizationId: string): P
       .order('name');
 
     if (error) {
-      console.error('Error fetching teams with members:', error);
+      logger.error('Error fetching teams with members:', error);
       return [];
     }
 
@@ -87,7 +88,7 @@ export const getOptimizedTeamsByOrganization = async (organizationId: string): P
       };
     });
   } catch (error) {
-    console.error('Error in getOptimizedTeamsByOrganization:', error);
+    logger.error('Error in getOptimizedTeamsByOrganization:', error);
     return [];
   }
 };
@@ -117,7 +118,7 @@ export const getOptimizedWorkOrdersByOrganization = async (organizationId: strin
       .order('created_date', { ascending: false });
 
     if (error) {
-      console.error('Error fetching optimized work orders:', error);
+      logger.error('Error fetching optimized work orders:', error);
       return [];
     }
 
@@ -128,7 +129,7 @@ export const getOptimizedWorkOrdersByOrganization = async (organizationId: strin
       equipmentName: (wo.equipment as any)?.name
     }));
   } catch (error) {
-    console.error('Error in getOptimizedWorkOrdersByOrganization:', error);
+    logger.error('Error in getOptimizedWorkOrdersByOrganization:', error);
     return [];
   }
 };
@@ -160,7 +161,7 @@ export const getOptimizedDashboardStats = async (organizationId: string): Promis
       pendingWorkOrders: workOrders.filter(wo => !['completed', 'cancelled'].includes(wo.status)).length
     };
   } catch (error) {
-    console.error('Error in getOptimizedDashboardStats:', error);
+    logger.error('Error in getOptimizedDashboardStats:', error);
     return {
       totalEquipment: 0,
       activeEquipment: 0,
@@ -192,7 +193,7 @@ export const getOptimizedNotesByEquipmentId = async (organizationId: string, equ
       .order('created_at', { ascending: false });
 
     if (error) {
-      console.error('Error fetching optimized notes:', error);
+      logger.error('Error fetching optimized notes:', error);
       return [];
     }
 
@@ -201,7 +202,7 @@ export const getOptimizedNotesByEquipmentId = async (organizationId: string, equ
       authorName: (note.author as any)?.name || 'Unknown'
     }));
   } catch (error) {
-    console.error('Error in getOptimizedNotesByEquipmentId:', error);
+    logger.error('Error in getOptimizedNotesByEquipmentId:', error);
     return [];
   }
 };
@@ -216,13 +217,13 @@ export const getOptimizedEquipmentByOrganization = async (organizationId: string
       .order('name');
 
     if (error) {
-      console.error('Error fetching equipment:', error);
+      logger.error('Error fetching equipment:', error);
       return [];
     }
 
     return data || [];
   } catch (error) {
-    console.error('Error in getOptimizedEquipmentByOrganization:', error);
+    logger.error('Error in getOptimizedEquipmentByOrganization:', error);
     return [];
   }
 };
@@ -253,7 +254,7 @@ export const getOptimizedWorkOrderById = async (organizationId: string, workOrde
       .single();
 
     if (error || !data) {
-      console.error('Error fetching optimized work order by ID:', error);
+      logger.error('Error fetching optimized work order by ID:', error);
       return undefined;
     }
 
@@ -264,7 +265,7 @@ export const getOptimizedWorkOrderById = async (organizationId: string, workOrde
       equipmentName: (data.equipment as any)?.name
     };
   } catch (error) {
-    console.error('Error in getOptimizedWorkOrderById:', error);
+    logger.error('Error in getOptimizedWorkOrderById:', error);
     return undefined;
   }
 };

--- a/src/services/optimizedTeamService.ts
+++ b/src/services/optimizedTeamService.ts
@@ -1,3 +1,4 @@
+import { logger } from '../utils/logger';
 import { supabase } from '@/integrations/supabase/client';
 
 export interface OptimizedTeam {
@@ -48,7 +49,7 @@ export const getTeamMembersOptimized = async (teamId: string): Promise<Optimized
       user_email: member.profiles?.email
     }));
   } catch (error) {
-    console.error('Error fetching team members:', error);
+    logger.error('Error fetching team members:', error);
     return [];
   }
 };
@@ -77,7 +78,7 @@ export const getOrganizationTeamsOptimized = async (organizationId: string): Pro
       updated_at: team.updated_at
     }));
   } catch (error) {
-    console.error('Error fetching organization teams:', error);
+    logger.error('Error fetching organization teams:', error);
     return [];
   }
 };
@@ -109,7 +110,7 @@ export const getTeamByIdOptimized = async (teamId: string): Promise<OptimizedTea
       updated_at: data.updated_at
     };
   } catch (error) {
-    console.error('Error fetching team by ID:', error);
+    logger.error('Error fetching team by ID:', error);
     return null;
   }
 };
@@ -128,7 +129,7 @@ export const isTeamManager = async (userId: string, teamId: string): Promise<boo
     if (error && error.code !== 'PGRST116') throw error;
     return !!data;
   } catch (error) {
-    console.error('Error checking team manager status:', error);
+    logger.error('Error checking team manager status:', error);
     return false;
   }
 };

--- a/src/services/optimizedWorkOrderService.ts
+++ b/src/services/optimizedWorkOrderService.ts
@@ -1,3 +1,4 @@
+import { logger } from '../utils/logger';
 
 import { supabase } from '@/integrations/supabase/client';
 import { EnhancedWorkOrder } from './workOrdersEnhancedService';
@@ -143,7 +144,7 @@ export const getFilteredWorkOrdersByOrganization = async (
       createdByName: wo.creator?.name
     }));
   } catch (error) {
-    console.error('Error fetching filtered work orders:', error);
+    logger.error('Error fetching filtered work orders:', error);
     throw error;
   }
 };

--- a/src/services/permissions/PermissionEngine.ts
+++ b/src/services/permissions/PermissionEngine.ts
@@ -1,3 +1,4 @@
+import { logger } from '../../utils/logger';
 import { UserContext, PermissionRule, PermissionCache } from '@/types/permissions';
 
 type EntityContext = { teamId?: string; assigneeId?: string; [key: string]: unknown };
@@ -224,7 +225,7 @@ export class PermissionEngine {
           return true;
         }
       } catch (error) {
-        console.warn(`Permission rule ${rule.name} failed:`, error);
+        logger.warn(`Permission rule ${rule.name} failed:`, error);
       }
     }
 

--- a/src/services/preventativeMaintenanceService.ts
+++ b/src/services/preventativeMaintenanceService.ts
@@ -1,3 +1,4 @@
+import { logger } from '../utils/logger';
 
 import { supabase } from '@/integrations/supabase/client';
 import { Tables, Database, Json } from '@/integrations/supabase/types';
@@ -885,7 +886,7 @@ export const createPM = async (data: CreatePMData): Promise<PreventativeMaintena
   try {
     const { data: userData } = await supabase.auth.getUser();
     if (!userData.user) {
-      console.error('User not authenticated');
+      logger.error('User not authenticated');
       return null;
     }
 
@@ -905,13 +906,13 @@ export const createPM = async (data: CreatePMData): Promise<PreventativeMaintena
       .single();
 
     if (error) {
-      console.error('Error creating PM:', error);
+      logger.error('Error creating PM:', error);
       return null;
     }
 
     return pm;
   } catch (error) {
-    console.error('Error in createPM:', error);
+    logger.error('Error in createPM:', error);
     return null;
   }
 };
@@ -926,13 +927,13 @@ export const getPMByWorkOrderId = async (workOrderId: string): Promise<Preventat
       .single();
 
     if (error && error.code !== 'PGRST116') {
-      console.error('Error fetching PM:', error);
+      logger.error('Error fetching PM:', error);
       return null;
     }
 
     return data || null;
   } catch (error) {
-    console.error('Error in getPMByWorkOrderId:', error);
+    logger.error('Error in getPMByWorkOrderId:', error);
     return null;
   }
 };
@@ -942,7 +943,7 @@ export const updatePM = async (pmId: string, data: UpdatePMData): Promise<Preven
   try {
     const { data: userData } = await supabase.auth.getUser();
     if (!userData.user) {
-      console.error('User not authenticated');
+      logger.error('User not authenticated');
       return null;
     }
 
@@ -968,13 +969,13 @@ export const updatePM = async (pmId: string, data: UpdatePMData): Promise<Preven
       .single();
 
     if (error) {
-      console.error('Error updating PM:', error);
+      logger.error('Error updating PM:', error);
       return null;
     }
 
     return pm;
   } catch (error) {
-    console.error('Error in updatePM:', error);
+    logger.error('Error in updatePM:', error);
     return null;
   }
 };
@@ -986,13 +987,13 @@ export const getLatestCompletedPM = async (equipmentId: string) => {
       .rpc('get_latest_completed_pm', { equipment_uuid: equipmentId });
 
     if (error) {
-      console.error('Error fetching latest PM:', error);
+      logger.error('Error fetching latest PM:', error);
       return null;
     }
 
     return data?.[0] || null;
   } catch (error) {
-    console.error('Error in getLatestCompletedPM:', error);
+    logger.error('Error in getLatestCompletedPM:', error);
     return null;
   }
 };
@@ -1006,13 +1007,13 @@ export const deletePM = async (pmId: string): Promise<boolean> => {
       .eq('id', pmId);
 
     if (error) {
-      console.error('Error deleting PM:', error);
+      logger.error('Error deleting PM:', error);
       return false;
     }
 
     return true;
   } catch (error) {
-    console.error('Error in deletePM:', error);
+    logger.error('Error in deletePM:', error);
     return false;
   }
 };

--- a/src/services/sessionStorageService.ts
+++ b/src/services/sessionStorageService.ts
@@ -1,3 +1,4 @@
+import { logger } from '../utils/logger';
 import { SessionData } from '@/contexts/SessionContext';
 import { 
   getSessionStorageKey, 
@@ -18,7 +19,7 @@ export class SessionStorageService {
       
       // Check version compatibility - force refresh due to RLS changes
       if (parsed.version !== SESSION_VERSION) {
-        console.log('🔄 Session version updated, clearing stored data');
+        logger.info('🔄 Session version updated, clearing stored data');
         localStorage.removeItem(SESSION_STORAGE_KEY);
         return null;
       }
@@ -28,14 +29,14 @@ export class SessionStorageService {
       const fourHoursAgo = new Date(Date.now() - 4 * 60 * 60 * 1000);
       
       if (lastUpdated < fourHoursAgo) {
-        console.log('⏰ Session data is older than 4 hours, will refresh on next fetch');
+        logger.info('⏰ Session data is older than 4 hours, will refresh on next fetch');
         // Don't clear immediately, but mark for refresh
         return parsed;
       }
       
       return parsed;
     } catch (error) {
-      console.error('💥 Error loading session from storage:', error);
+      logger.error('💥 Error loading session from storage:', error);
       localStorage.removeItem(SESSION_STORAGE_KEY);
       return null;
     }
@@ -45,7 +46,7 @@ export class SessionStorageService {
     try {
       localStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(data));
     } catch (error) {
-      console.error('💾 Error saving session to storage:', error);
+      logger.error('💾 Error saving session to storage:', error);
     }
   }
 

--- a/src/services/supabaseDataService.ts
+++ b/src/services/supabaseDataService.ts
@@ -1,3 +1,4 @@
+import { logger } from '../utils/logger';
 import { supabase } from '@/integrations/supabase/client';
 import { Tables } from '@/integrations/supabase/types';
 
@@ -45,13 +46,13 @@ export const getEquipmentByOrganization = async (organizationId: string): Promis
       .order('name');
 
     if (error) {
-      console.error('Error fetching equipment:', error);
+      logger.error('Error fetching equipment:', error);
       return [];
     }
 
     return data || [];
   } catch (error) {
-    console.error('Error in getEquipmentByOrganization:', error);
+    logger.error('Error in getEquipmentByOrganization:', error);
     return [];
   }
 };
@@ -66,13 +67,13 @@ export const getEquipmentById = async (organizationId: string, equipmentId: stri
       .single();
 
     if (error || !data) {
-      console.error('Error fetching equipment by ID:', error);
+      logger.error('Error fetching equipment by ID:', error);
       return undefined;
     }
 
     return data;
   } catch (error) {
-    console.error('Error in getEquipmentById:', error);
+    logger.error('Error in getEquipmentById:', error);
     return undefined;
   }
 };
@@ -88,7 +89,7 @@ export const getTeamsByOrganization = async (organizationId: string): Promise<Te
       .order('name');
 
     if (teamsError) {
-      console.error('Error fetching teams:', teamsError);
+      logger.error('Error fetching teams:', teamsError);
       return [];
     }
 
@@ -115,7 +116,7 @@ export const getTeamsByOrganization = async (organizationId: string): Promise<Te
       .in('team_id', teamIds);
 
     if (membersError) {
-      console.error('Error fetching team members:', membersError);
+      logger.error('Error fetching team members:', membersError);
     }
 
     // Get work order counts for teams through equipment
@@ -126,7 +127,7 @@ export const getTeamsByOrganization = async (organizationId: string): Promise<Te
       .in('team_id', teamIds);
 
     if (equipmentError) {
-      console.error('Error fetching equipment for work order counts:', equipmentError);
+      logger.error('Error fetching equipment for work order counts:', equipmentError);
     }
 
     // Get work order counts
@@ -140,7 +141,7 @@ export const getTeamsByOrganization = async (organizationId: string): Promise<Te
       { data: [], error: null };
 
     if (workOrderError) {
-      console.error('Error fetching work order counts:', workOrderError);
+      logger.error('Error fetching work order counts:', workOrderError);
     }
 
     // Build teams with member and work order data
@@ -169,7 +170,7 @@ export const getTeamsByOrganization = async (organizationId: string): Promise<Te
       };
     });
   } catch (error) {
-    console.error('Error in getTeamsByOrganization:', error);
+    logger.error('Error in getTeamsByOrganization:', error);
     return [];
   }
 };
@@ -184,7 +185,7 @@ export const getDashboardStatsByOrganization = async (organizationId: string): P
       .eq('organization_id', organizationId);
 
     if (equipmentError) {
-      console.error('Error fetching equipment stats:', equipmentError);
+      logger.error('Error fetching equipment stats:', equipmentError);
     }
 
     // Get work order stats
@@ -194,7 +195,7 @@ export const getDashboardStatsByOrganization = async (organizationId: string): P
       .eq('organization_id', organizationId);
 
     if (workOrderError) {
-      console.error('Error fetching work order stats:', workOrderError);
+      logger.error('Error fetching work order stats:', workOrderError);
     }
 
     const equipment = equipmentData || [];
@@ -207,7 +208,7 @@ export const getDashboardStatsByOrganization = async (organizationId: string): P
       totalWorkOrders: workOrders.length
     };
   } catch (error) {
-    console.error('Error in getDashboardStatsByOrganization:', error);
+    logger.error('Error in getDashboardStatsByOrganization:', error);
     return {
       totalEquipment: 0,
       activeEquipment: 0,
@@ -233,7 +234,7 @@ export const getNotesByEquipmentId = async (organizationId: string, equipmentId:
       .order('created_at', { ascending: false });
 
     if (error) {
-      console.error('Error fetching notes:', error);
+      logger.error('Error fetching notes:', error);
       return [];
     }
 
@@ -245,7 +246,7 @@ export const getNotesByEquipmentId = async (organizationId: string, equipmentId:
       .in('id', authorIds);
 
     if (profilesError) {
-      console.error('Error fetching author profiles:', profilesError);
+      logger.error('Error fetching author profiles:', profilesError);
     }
 
     return (data || []).map(note => ({
@@ -253,7 +254,7 @@ export const getNotesByEquipmentId = async (organizationId: string, equipmentId:
       authorName: profiles?.find(p => p.id === note.author_id)?.name || 'Unknown'
     }));
   } catch (error) {
-    console.error('Error in getNotesByEquipmentId:', error);
+    logger.error('Error in getNotesByEquipmentId:', error);
     return [];
   }
 };
@@ -269,7 +270,7 @@ export const getWorkOrdersByEquipmentId = async (organizationId: string, equipme
       .order('created_date', { ascending: false });
 
     if (error) {
-      console.error('Error fetching work orders:', error);
+      logger.error('Error fetching work orders:', error);
       return [];
     }
 
@@ -295,7 +296,7 @@ export const getWorkOrdersByEquipmentId = async (organizationId: string, equipme
       teamName: undefined // Team info now comes from equipment assignment
     }));
   } catch (error) {
-    console.error('Error in getWorkOrdersByEquipmentId:', error);
+    logger.error('Error in getWorkOrdersByEquipmentId:', error);
     return [];
   }
 };
@@ -310,7 +311,7 @@ export const getAllWorkOrdersByOrganization = async (organizationId: string): Pr
       .order('created_date', { ascending: false });
 
     if (workOrdersError) {
-      console.error('Error fetching all work orders:', workOrdersError);
+      logger.error('Error fetching all work orders:', workOrdersError);
       return [];
     }
 
@@ -327,7 +328,7 @@ export const getAllWorkOrdersByOrganization = async (organizationId: string): Pr
       { data: [], error: null };
 
     if (profilesError) {
-      console.error('Error fetching assignee profiles:', profilesError);
+      logger.error('Error fetching assignee profiles:', profilesError);
     }
 
     // Combine work orders with assignee names
@@ -337,7 +338,7 @@ export const getAllWorkOrdersByOrganization = async (organizationId: string): Pr
       teamName: undefined // Team info now comes from equipment assignment
     }));
   } catch (error) {
-    console.error('Error in getAllWorkOrdersByOrganization:', error);
+    logger.error('Error in getAllWorkOrdersByOrganization:', error);
     return [];
   }
 };
@@ -352,7 +353,7 @@ export const getWorkOrderById = async (organizationId: string, workOrderId: stri
       .single();
 
     if (error || !data) {
-      console.error('Error fetching work order by ID:', error);
+      logger.error('Error fetching work order by ID:', error);
       return undefined;
     }
 
@@ -367,7 +368,7 @@ export const getWorkOrderById = async (organizationId: string, workOrderId: stri
       teamName: undefined // Team info now comes from equipment assignment
     };
   } catch (error) {
-    console.error('Error in getWorkOrderById:', error);
+    logger.error('Error in getWorkOrderById:', error);
     return undefined;
   }
 };
@@ -388,7 +389,7 @@ export const getScansByEquipmentId = async (organizationId: string, equipmentId:
       .order('scanned_at', { ascending: false });
 
     if (error) {
-      console.error('Error fetching scans:', error);
+      logger.error('Error fetching scans:', error);
       return [];
     }
 
@@ -400,7 +401,7 @@ export const getScansByEquipmentId = async (organizationId: string, equipmentId:
       .in('id', userIds);
 
     if (profilesError) {
-      console.error('Error fetching user profiles:', profilesError);
+      logger.error('Error fetching user profiles:', profilesError);
     }
 
     return (data || []).map(scan => ({
@@ -408,7 +409,7 @@ export const getScansByEquipmentId = async (organizationId: string, equipmentId:
       scannedByName: profiles?.find(p => p.id === scan.scanned_by)?.name || 'Unknown'
     }));
   } catch (error) {
-    console.error('Error in getScansByEquipmentId:', error);
+    logger.error('Error in getScansByEquipmentId:', error);
     return [];
   }
 };
@@ -423,7 +424,7 @@ export const createScan = async (
   try {
     const { data: userData } = await supabase.auth.getUser();
     if (!userData.user) {
-      console.error('User not authenticated');
+      logger.error('User not authenticated');
       return null;
     }
 
@@ -439,7 +440,7 @@ export const createScan = async (
       .single();
 
     if (error) {
-      console.error('Error creating scan:', error);
+      logger.error('Error creating scan:', error);
       return null;
     }
 
@@ -455,7 +456,7 @@ export const createScan = async (
       scannedByName: profile?.name || 'Unknown'
     };
   } catch (error) {
-    console.error('Error in createScan:', error);
+    logger.error('Error in createScan:', error);
     return null;
   }
 };
@@ -481,13 +482,13 @@ export const updateWorkOrderStatus = async (
       .eq('organization_id', organizationId);
 
     if (error) {
-      console.error('Error updating work order status:', error);
+      logger.error('Error updating work order status:', error);
       return false;
     }
 
     return true;
   } catch (error) {
-    console.error('Error in updateWorkOrderStatus:', error);
+    logger.error('Error in updateWorkOrderStatus:', error);
     return false;
   }
 };
@@ -508,13 +509,13 @@ export const createEquipment = async (
       .single();
 
     if (error) {
-      console.error('Error creating equipment:', error);
+      logger.error('Error creating equipment:', error);
       return null;
     }
 
     return data;
   } catch (error) {
-    console.error('Error in createEquipment:', error);
+    logger.error('Error in createEquipment:', error);
     return null;
   }
 };
@@ -527,7 +528,7 @@ export const createWorkOrder = async (
   try {
     const { data: userData } = await supabase.auth.getUser();
     if (!userData.user) {
-      console.error('User not authenticated');
+      logger.error('User not authenticated');
       return null;
     }
 
@@ -542,7 +543,7 @@ export const createWorkOrder = async (
       .single();
 
     if (error) {
-      console.error('Error creating work order:', error);
+      logger.error('Error creating work order:', error);
       return null;
     }
 
@@ -557,7 +558,7 @@ export const createWorkOrder = async (
       teamName: undefined // Team info now comes from equipment assignment
     };
   } catch (error) {
-    console.error('Error in createWorkOrder:', error);
+    logger.error('Error in createWorkOrder:', error);
     return null;
   }
 };
@@ -572,7 +573,7 @@ export const createNote = async (
   try {
     const { data: userData } = await supabase.auth.getUser();
     if (!userData.user) {
-      console.error('User not authenticated');
+      logger.error('User not authenticated');
       return null;
     }
 
@@ -588,7 +589,7 @@ export const createNote = async (
       .single();
 
     if (error) {
-      console.error('Error creating note:', error);
+      logger.error('Error creating note:', error);
       return null;
     }
 
@@ -604,7 +605,7 @@ export const createNote = async (
       authorName: profile?.name || 'Unknown'
     };
   } catch (error) {
-    console.error('Error in createNote:', error);
+    logger.error('Error in createNote:', error);
     return null;
   }
 };
@@ -625,13 +626,13 @@ export const updateEquipment = async (
       .single();
 
     if (error) {
-      console.error('Error updating equipment:', error);
+      logger.error('Error updating equipment:', error);
       return null;
     }
 
     return data;
   } catch (error) {
-    console.error('Error in updateEquipment:', error);
+    logger.error('Error in updateEquipment:', error);
     return null;
   }
 };

--- a/src/services/teamBasedDashboardService.ts
+++ b/src/services/teamBasedDashboardService.ts
@@ -1,3 +1,4 @@
+import { logger } from '../utils/logger';
 import { supabase } from '@/integrations/supabase/client';
 import { getAccessibleEquipmentIds } from './teamBasedEquipmentService';
 
@@ -53,7 +54,7 @@ export const getTeamBasedDashboardStats = async (
     const { data: equipmentData, error: equipmentError } = await equipmentQuery;
 
     if (equipmentError) {
-      console.error('Error fetching equipment stats:', equipmentError);
+      logger.error('Error fetching equipment stats:', equipmentError);
       throw equipmentError;
     }
 
@@ -80,7 +81,7 @@ export const getTeamBasedDashboardStats = async (
     const { data: workOrderData, error: workOrderError } = await workOrderQuery;
 
     if (workOrderError) {
-      console.error('Error fetching work order stats:', workOrderError);
+      logger.error('Error fetching work order stats:', workOrderError);
       throw workOrderError;
     }
 
@@ -113,7 +114,7 @@ export const getTeamBasedDashboardStats = async (
     const { data: teamData, error: teamError } = await teamQuery;
 
     if (teamError) {
-      console.error('Error fetching team stats:', teamError);
+      logger.error('Error fetching team stats:', teamError);
       throw teamError;
     }
 
@@ -130,7 +131,7 @@ export const getTeamBasedDashboardStats = async (
     return stats;
 
   } catch (error) {
-    console.error('Error in getTeamBasedDashboardStats:', error);
+    logger.error('Error in getTeamBasedDashboardStats:', error);
     throw error;
   }
 };

--- a/src/services/teamBasedEquipmentService.ts
+++ b/src/services/teamBasedEquipmentService.ts
@@ -1,3 +1,4 @@
+import { logger } from '../utils/logger';
 
 import { supabase } from '@/integrations/supabase/client';
 
@@ -53,7 +54,7 @@ export const getTeamAccessibleEquipment = async (
     const { data, error } = await query.order('name', { ascending: true });
 
     if (error) {
-      console.error('❌ Error fetching team-accessible equipment:', error);
+      logger.error('❌ Error fetching team-accessible equipment:', error);
       throw error;
     }
 
@@ -70,7 +71,7 @@ export const getTeamAccessibleEquipment = async (
       team_name: equipment.teams?.name
     }));
   } catch (error) {
-    console.error('Error in getTeamAccessibleEquipment:', error);
+    logger.error('Error in getTeamAccessibleEquipment:', error);
     throw error;
   }
 };
@@ -85,7 +86,7 @@ export const getAccessibleEquipmentIds = async (
     const equipment = await getTeamAccessibleEquipment(organizationId, userTeamIds, isOrgAdmin);
     return equipment.map(e => e.id);
   } catch (error) {
-    console.error('Error getting accessible equipment IDs:', error);
+    logger.error('Error getting accessible equipment IDs:', error);
     return [];
   }
 };

--- a/src/services/teamBasedWorkOrderService.ts
+++ b/src/services/teamBasedWorkOrderService.ts
@@ -1,3 +1,4 @@
+import { logger } from '../utils/logger';
 
 import { supabase } from '@/integrations/supabase/client';
 import { EnhancedWorkOrder } from '@/services/workOrdersEnhancedService';
@@ -110,7 +111,7 @@ export const getTeamBasedWorkOrders = async (
     const { data, error } = await query;
 
     if (error) {
-      console.error('❌ Error fetching team-based work orders:', error);
+      logger.error('❌ Error fetching team-based work orders:', error);
       throw error;
     }
 
@@ -135,7 +136,7 @@ export const getTeamBasedWorkOrders = async (
       createdByName: wo.creator?.name
     }));
   } catch (error) {
-    console.error('Error in getTeamBasedWorkOrders:', error);
+    logger.error('Error in getTeamBasedWorkOrders:', error);
     throw error;
   }
 };

--- a/src/services/workOrderCSVService.ts
+++ b/src/services/workOrderCSVService.ts
@@ -1,3 +1,4 @@
+import { logger } from '../utils/logger';
 import { supabase } from '@/integrations/supabase/client';
 
 export interface WorkOrderCost {
@@ -64,7 +65,7 @@ export const generateCostsCSV = async (workOrderId: string): Promise<void> => {
     document.body.removeChild(link);
     window.URL.revokeObjectURL(url);
   } catch (error) {
-    console.error('Error generating costs CSV:', error);
+    logger.error('Error generating costs CSV:', error);
     throw error;
   }
 };

--- a/src/services/workOrderCostsOptimizedService.ts
+++ b/src/services/workOrderCostsOptimizedService.ts
@@ -1,3 +1,4 @@
+import { logger } from '../utils/logger';
 import { supabase } from '@/integrations/supabase/client';
 
 export interface WorkOrderCost {
@@ -54,7 +55,7 @@ export const getMyCosts = async (organizationId: string, userId: string): Promis
       workOrderTitle: cost.work_orders?.title
     }));
   } catch (error) {
-    console.error('Error fetching user costs:', error);
+    logger.error('Error fetching user costs:', error);
     return [];
   }
 };
@@ -98,7 +99,7 @@ export const getAllCostsWithCreators = async (organizationId: string): Promise<W
       workOrderTitle: cost.work_orders?.title
     }));
   } catch (error) {
-    console.error('Error fetching all costs:', error);
+    logger.error('Error fetching all costs:', error);
     return [];
   }
 };
@@ -151,7 +152,7 @@ export const getCostSummaryByUser = async (organizationId: string) => {
 
     return Object.values(summary);
   } catch (error) {
-    console.error('Error fetching cost summary:', error);
+    logger.error('Error fetching cost summary:', error);
     return [];
   }
 };

--- a/src/services/workOrderCostsService.ts
+++ b/src/services/workOrderCostsService.ts
@@ -1,3 +1,4 @@
+import { logger } from '../utils/logger';
 
 import { supabase } from '@/integrations/supabase/client';
 
@@ -62,7 +63,7 @@ export const getWorkOrderCosts = async (workOrderId: string): Promise<WorkOrderC
       created_by_name: profilesMap[cost.created_by] || 'Unknown'
     }));
   } catch (error) {
-    console.error('Error fetching work order costs:', error);
+    logger.error('Error fetching work order costs:', error);
     throw error;
   }
 };
@@ -96,7 +97,7 @@ export const createWorkOrderCost = async (costData: CreateWorkOrderCostData): Pr
       created_by_name: profile?.name || 'Unknown'
     };
   } catch (error) {
-    console.error('Error creating work order cost:', error);
+    logger.error('Error creating work order cost:', error);
     throw error;
   }
 };
@@ -128,7 +129,7 @@ export const updateWorkOrderCost = async (
       created_by_name: profile?.name || 'Unknown'
     };
   } catch (error) {
-    console.error('Error updating work order cost:', error);
+    logger.error('Error updating work order cost:', error);
     throw error;
   }
 };
@@ -143,7 +144,7 @@ export const deleteWorkOrderCost = async (costId: string): Promise<void> => {
 
     if (error) throw error;
   } catch (error) {
-    console.error('Error deleting work order cost:', error);
+    logger.error('Error deleting work order cost:', error);
     throw error;
   }
 };

--- a/src/services/workOrderDataService.ts
+++ b/src/services/workOrderDataService.ts
@@ -1,3 +1,4 @@
+import { logger } from '../utils/logger';
 
 import { supabase } from '@/integrations/supabase/client';
 
@@ -58,7 +59,7 @@ export const getWorkOrderByIdWithAssignee = async (
       .single();
 
     if (error || !data) {
-      console.error('Error fetching work order with assignee:', error);
+      logger.error('Error fetching work order with assignee:', error);
       return null;
     }
 
@@ -87,7 +88,7 @@ export const getWorkOrderByIdWithAssignee = async (
       updated_at: data.updated_at
     };
   } catch (error) {
-    console.error('Error in getWorkOrderByIdWithAssignee:', error);
+    logger.error('Error in getWorkOrderByIdWithAssignee:', error);
     return null;
   }
 };

--- a/src/services/workOrderNotesService.ts
+++ b/src/services/workOrderNotesService.ts
@@ -1,3 +1,4 @@
+import { logger } from '../utils/logger';
 
 import { supabase } from '@/integrations/supabase/client';
 
@@ -67,7 +68,7 @@ export const createWorkOrderNoteWithImages = async (
         .upload(fileName, file);
 
       if (uploadError) {
-        console.error('Failed to upload image:', uploadError);
+        logger.error('Failed to upload image:', uploadError);
         continue;
       }
 
@@ -93,7 +94,7 @@ export const createWorkOrderNoteWithImages = async (
         .single();
 
       if (imageError) {
-        console.error('Failed to save image record:', imageError);
+        logger.error('Failed to save image record:', imageError);
         continue;
       }
 
@@ -102,7 +103,7 @@ export const createWorkOrderNoteWithImages = async (
         note_id: note.id
       });
     } catch (error) {
-      console.error('Error processing image:', error);
+      logger.error('Error processing image:', error);
     }
   }
 
@@ -178,7 +179,7 @@ export const getWorkOrderNotesWithImages = async (workOrderId: string) => {
       };
     });
   } catch (error) {
-    console.error('Error fetching work order notes:', error);
+    logger.error('Error fetching work order notes:', error);
     return [];
   }
 };
@@ -219,7 +220,7 @@ export const getWorkOrderImages = async (workOrderId: string) => {
       };
     });
   } catch (error) {
-    console.error('Error fetching work order images:', error);
+    logger.error('Error fetching work order images:', error);
     return [];
   }
 };

--- a/src/services/workOrderPDFService.ts
+++ b/src/services/workOrderPDFService.ts
@@ -1,3 +1,4 @@
+import { logger } from '../utils/logger';
 import jsPDF from 'jspdf';
 import { supabase } from '@/integrations/supabase/client';
 
@@ -91,7 +92,7 @@ export const generatePMChecklistPDF = async (workOrderId: string): Promise<void>
     // Download
     pdf.save(`PM-Checklist-${workOrder.title}-${Date.now()}.pdf`);
   } catch (error) {
-    console.error('Error generating PM PDF:', error);
+    logger.error('Error generating PM PDF:', error);
     throw error;
   }
 };

--- a/src/services/workOrderRevertService.ts
+++ b/src/services/workOrderRevertService.ts
@@ -1,3 +1,4 @@
+import { logger } from '../utils/logger';
 import { supabase } from '@/integrations/supabase/client';
 
 export interface RevertResult {
@@ -18,7 +19,7 @@ export const workOrderRevertService = {
       if (error) throw error;
       return data as unknown as RevertResult;
     } catch (error) {
-      console.error('Error reverting work order status:', error);
+      logger.error('Error reverting work order status:', error);
       return {
         success: false,
         error: error instanceof Error ? error.message : 'Failed to revert work order status'
@@ -36,7 +37,7 @@ export const workOrderRevertService = {
       if (error) throw error;
       return data as unknown as RevertResult;
     } catch (error) {
-      console.error('Error reverting PM completion:', error);
+      logger.error('Error reverting PM completion:', error);
       return {
         success: false,
         error: error instanceof Error ? error.message : 'Failed to revert PM completion'
@@ -61,7 +62,7 @@ export const workOrderRevertService = {
       if (error) throw error;
       return { data, error: null };
     } catch (error) {
-      console.error('Error fetching work order history:', error);
+      logger.error('Error fetching work order history:', error);
       return { data: null, error };
     }
   },
@@ -83,7 +84,7 @@ export const workOrderRevertService = {
       if (error) throw error;
       return { data, error: null };
     } catch (error) {
-      console.error('Error fetching PM history:', error);
+      logger.error('Error fetching PM history:', error);
       return { data: null, error };
     }
   }

--- a/src/services/workOrdersEnhancedService.ts
+++ b/src/services/workOrdersEnhancedService.ts
@@ -1,3 +1,4 @@
+import { logger } from '../utils/logger';
 
 import { supabase } from '@/integrations/supabase/client';
 
@@ -84,7 +85,7 @@ export const getEnhancedWorkOrdersByOrganization = async (organizationId: string
       createdByName: wo.creator?.name
     }));
   } catch (error) {
-    console.error('Error fetching enhanced work orders:', error);
+    logger.error('Error fetching enhanced work orders:', error);
     throw error;
   }
 };


### PR DESCRIPTION
## Summary
- import shared logger into service layer
- replace console.log/error/warn with logger methods for consistent messaging

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68a76cf9da50832590d2231013528320