### PR TITLE
test: type-safe a11y helpers

### DIFF
--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -2,6 +2,12 @@ import '@testing-library/jest-dom';
 import { afterEach, beforeAll, vi } from 'vitest';
 import { cleanup } from '@testing-library/react';
 
+declare global {
+  // Expose A11y control functions for tests
+  let startA11yChecks: () => void;
+  let stopA11yChecks: () => void;
+}
+
 // Mock react-router-dom with proper MemoryRouter export
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom');
@@ -179,8 +185,8 @@ beforeAll(() => {
   };
 
   // Make a11y functions globally available for tests
-  (global as any).startA11yChecks = startA11yChecks;
-  (global as any).stopA11yChecks = stopA11yChecks;
+  globalThis.startA11yChecks = startA11yChecks;
+  globalThis.stopA11yChecks = stopA11yChecks;
 
   // Ensure consistent global objects across Node versions
   if (typeof global.structuredClone === 'undefined') {


### PR DESCRIPTION
## Summary
- declare typed globals for accessibility helper functions in test setup
- expose `startA11yChecks` and `stopA11yChecks` via `globalThis`

## Testing
- `npx eslint src/test/setup.ts`
- `npx tsc -p tsconfig.json --noEmit`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68a7c2e05f048325b42d3c245df429cd