### PR TITLE
Fix session test and lint issues

### DIFF
--- a/src/hooks/__tests__/useSession.test.tsx
+++ b/src/hooks/__tests__/useSession.test.tsx
@@ -11,8 +11,8 @@ const TestComponent = () => {
     <div>
       <div data-testid="is-loading">{isLoading.toString()}</div>
       <div data-testid="has-error">{(error ? 'true' : 'false')}</div>
-      <div data-testid="current-org-id">{sessionData?.currentOrganizationId || 'none'}</div>
-      <div data-testid="user-id">{sessionData?.session?.user?.id || 'user-1'}</div>
+        <div data-testid="current-org-id">{sessionData?.currentOrganizationId || 'none'}</div>
+        <div data-testid="user-id">{'user' in (sessionData || {}) ? (sessionData as any).user?.id : 'none'}</div>
       <button 
         data-testid="refresh-button" 
         onClick={() => refreshSession()}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -6,12 +6,6 @@ declare global {
   // Expose A11y control functions for tests
   let startA11yChecks: () => void;
   let stopA11yChecks: () => void;
-  
-  // Extend globalThis to include our functions
-  namespace globalThis {
-    var startA11yChecks: () => void;
-    var stopA11yChecks: () => void;
-  }
 }
 
 // Mock react-router-dom with proper MemoryRouter export


### PR DESCRIPTION
## Summary
- remove namespace+var usage in test setup to satisfy eslint
- handle missing user id in useSession test component

## Testing
- `npm run lint`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68a7dc63bf2883259ca96791996091cb