### PR TITLE
refactor: lazy load pages and fix session test types

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,36 +1,38 @@
 
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, Navigate, useParams } from 'react-router-dom';
+import { Suspense, lazy } from 'react';
 import { AppProviders } from '@/components/providers/AppProviders';
 import { TeamProvider } from '@/contexts/TeamContext';
 import { SimpleOrganizationProvider } from '@/contexts/SimpleOrganizationProvider'; // Fixed import path
 import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar';
 import ProtectedRoute from '@/components/auth/ProtectedRoute';
-import AppSidebar from '@/components/layout/AppSidebar';
-import TopBar from '@/components/layout/TopBar';
 
-import { Navigate, useParams } from 'react-router-dom';
-import Auth from '@/pages/Auth';
-import SmartLanding from '@/components/landing/SmartLanding';
-import Dashboard from '@/pages/Dashboard';
-import Equipment from '@/pages/Equipment';
-import EquipmentDetails from '@/pages/EquipmentDetails';
-import WorkOrders from '@/pages/WorkOrders';
-import WorkOrderDetails from '@/pages/WorkOrderDetails';
-import Teams from '@/pages/Teams';
-import TeamDetails from '@/pages/TeamDetails';
-import FleetMap from '@/pages/FleetMap';
-import Organization from '@/pages/Organization';
-import QRScanner from '@/pages/QRScanner';
-import QRRedirect from '@/pages/QRRedirect';
-import Billing from '@/pages/Billing';
-import Settings from '@/pages/Settings';
-import Reports from '@/pages/Reports';
-import Support from '@/pages/Support';
-import PMTemplates from '@/pages/PMTemplates';
-import InvitationAccept from '@/pages/InvitationAccept';
-import TermsOfService from '@/pages/TermsOfService';
-import PrivacyPolicy from '@/pages/PrivacyPolicy';
-import LegalFooter from '@/components/layout/LegalFooter';
+// Lazy-loaded components to reduce initial bundle size
+const AppSidebar = lazy(() => import('@/components/layout/AppSidebar'));
+const TopBar = lazy(() => import('@/components/layout/TopBar'));
+const LegalFooter = lazy(() => import('@/components/layout/LegalFooter'));
+
+const Auth = lazy(() => import('@/pages/Auth'));
+const SmartLanding = lazy(() => import('@/components/landing/SmartLanding'));
+const Dashboard = lazy(() => import('@/pages/Dashboard'));
+const Equipment = lazy(() => import('@/pages/Equipment'));
+const EquipmentDetails = lazy(() => import('@/pages/EquipmentDetails'));
+const WorkOrders = lazy(() => import('@/pages/WorkOrders'));
+const WorkOrderDetails = lazy(() => import('@/pages/WorkOrderDetails'));
+const Teams = lazy(() => import('@/pages/Teams'));
+const TeamDetails = lazy(() => import('@/pages/TeamDetails'));
+const FleetMap = lazy(() => import('@/pages/FleetMap'));
+const Organization = lazy(() => import('@/pages/Organization'));
+const QRScanner = lazy(() => import('@/pages/QRScanner'));
+const QRRedirect = lazy(() => import('@/pages/QRRedirect'));
+const Billing = lazy(() => import('@/pages/Billing'));
+const Settings = lazy(() => import('@/pages/Settings'));
+const Reports = lazy(() => import('@/pages/Reports'));
+const Support = lazy(() => import('@/pages/Support'));
+const PMTemplates = lazy(() => import('@/pages/PMTemplates'));
+const InvitationAccept = lazy(() => import('@/pages/InvitationAccept'));
+const TermsOfService = lazy(() => import('@/pages/TermsOfService'));
+const PrivacyPolicy = lazy(() => import('@/pages/PrivacyPolicy'));
 
 
 const BrandedTopBar = () => {
@@ -51,69 +53,80 @@ const RedirectToWorkOrder = () => {
 function App() {
   return (
     <AppProviders>
-              <Routes>
-                {/* Public routes */}
-                <Route path="/" element={<SmartLanding />} />
-                <Route path="/auth" element={<Auth />} />
-                <Route path="/support" element={<Support />} />
-                <Route path="/invitation/:token" element={<InvitationAccept />} />
-                <Route path="/qr/:equipmentId" element={<QRRedirect />} />
-                <Route path="/terms-of-service" element={<TermsOfService />} />
-                <Route path="/privacy-policy" element={<PrivacyPolicy />} />
-                
-                {/* Redirect routes for backward compatibility */}
-                <Route path="/equipment/:equipmentId" element={
-                  <ProtectedRoute>
-                    <SimpleOrganizationProvider>
-                      <RedirectToEquipment />
-                    </SimpleOrganizationProvider>
-                  </ProtectedRoute>
-                } />
-                <Route path="/work-orders/:workOrderId" element={
-                  <ProtectedRoute>
-                    <SimpleOrganizationProvider>
-                      <RedirectToWorkOrder />
-                    </SimpleOrganizationProvider>
-                  </ProtectedRoute>
-                } />
-                
-                {/* Protected routes */}
-                <Route path="/dashboard/*" element={
-                  <ProtectedRoute>
-                    <SimpleOrganizationProvider>
-                      <TeamProvider>
-                      <SidebarProvider>
-                        <div className="flex min-h-screen w-full">
-                          <AppSidebar />
-                          <SidebarInset className="flex-1 min-w-0">
-                            <BrandedTopBar />
-                            <main className="flex-1 p-3 sm:p-4 lg:p-6 xl:p-8 overflow-auto min-w-0">
-                              <Routes>
-                                <Route path="/" element={<Dashboard />} />
-                                <Route path="/equipment" element={<Equipment />} />
-                                <Route path="/equipment/:equipmentId" element={<EquipmentDetails />} />
-                                <Route path="/work-orders" element={<WorkOrders />} />
-                                <Route path="/work-orders/:workOrderId" element={<WorkOrderDetails />} />
-                                <Route path="/teams" element={<Teams />} />
-                                <Route path="/teams/:teamId" element={<TeamDetails />} />
-                                <Route path="/fleet-map" element={<FleetMap />} />
-                                <Route path="/organization" element={<Organization />} />
-                                <Route path="/scanner" element={<QRScanner />} />
-                                <Route path="/billing" element={<Billing />} />
-                                <Route path="/pm-templates" element={<PMTemplates />} />
-                                <Route path="/settings" element={<Settings />} />
-                                <Route path="/reports" element={<Reports />} />
-                              </Routes>
-                            </main>
-                            <LegalFooter />
-                          </SidebarInset>
-                        </div>
-                        </SidebarProvider>
-                      </TeamProvider>
-                    </SimpleOrganizationProvider>
-                  </ProtectedRoute>
-                } />
-              </Routes>
+      <Suspense fallback={<div>Loading...</div>}>
+        <Routes>
+          {/* Public routes */}
+          <Route path="/" element={<SmartLanding />} />
+          <Route path="/auth" element={<Auth />} />
+          <Route path="/support" element={<Support />} />
+          <Route path="/invitation/:token" element={<InvitationAccept />} />
+          <Route path="/qr/:equipmentId" element={<QRRedirect />} />
+          <Route path="/terms-of-service" element={<TermsOfService />} />
+          <Route path="/privacy-policy" element={<PrivacyPolicy />} />
+
+          {/* Redirect routes for backward compatibility */}
+          <Route
+            path="/equipment/:equipmentId"
+            element={
+              <ProtectedRoute>
+                <SimpleOrganizationProvider>
+                  <RedirectToEquipment />
+                </SimpleOrganizationProvider>
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/work-orders/:workOrderId"
+            element={
+              <ProtectedRoute>
+                <SimpleOrganizationProvider>
+                  <RedirectToWorkOrder />
+                </SimpleOrganizationProvider>
+              </ProtectedRoute>
+            }
+          />
+
+          {/* Protected routes */}
+          <Route
+            path="/dashboard/*"
+            element={
+              <ProtectedRoute>
+                <SimpleOrganizationProvider>
+                  <TeamProvider>
+                    <SidebarProvider>
+                      <div className="flex min-h-screen w-full">
+                        <AppSidebar />
+                        <SidebarInset className="flex-1 min-w-0">
+                          <BrandedTopBar />
+                          <main className="flex-1 p-3 sm:p-4 lg:p-6 xl:p-8 overflow-auto min-w-0">
+                            <Routes>
+                              <Route path="/" element={<Dashboard />} />
+                              <Route path="/equipment" element={<Equipment />} />
+                              <Route path="/equipment/:equipmentId" element={<EquipmentDetails />} />
+                              <Route path="/work-orders" element={<WorkOrders />} />
+                              <Route path="/work-orders/:workOrderId" element={<WorkOrderDetails />} />
+                              <Route path="/teams" element={<Teams />} />
+                              <Route path="/teams/:teamId" element={<TeamDetails />} />
+                              <Route path="/fleet-map" element={<FleetMap />} />
+                              <Route path="/organization" element={<Organization />} />
+                              <Route path="/scanner" element={<QRScanner />} />
+                              <Route path="/billing" element={<Billing />} />
+                              <Route path="/pm-templates" element={<PMTemplates />} />
+                              <Route path="/settings" element={<Settings />} />
+                              <Route path="/reports" element={<Reports />} />
+                            </Routes>
+                          </main>
+                          <LegalFooter />
+                        </SidebarInset>
+                      </div>
+                    </SidebarProvider>
+                  </TeamProvider>
+                </SimpleOrganizationProvider>
+              </ProtectedRoute>
+            }
+          />
+        </Routes>
+      </Suspense>
     </AppProviders>
   );
 }

--- a/src/hooks/__tests__/useSession.test.tsx
+++ b/src/hooks/__tests__/useSession.test.tsx
@@ -1,8 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@/test/utils/test-utils';
 import { render as rtlRender } from '@testing-library/react';
-import { SessionContext } from '@/contexts/SessionContext';
+import { SessionContext, type SessionData } from '@/contexts/SessionContext';
 import { useSession } from '../useSession';
+
+interface SessionDataWithUser extends SessionData {
+  user?: { id?: string };
+}
 
 const TestComponent = () => {
   const { sessionData, isLoading, error, refreshSession } = useSession();
@@ -12,7 +16,7 @@ const TestComponent = () => {
       <div data-testid="is-loading">{isLoading.toString()}</div>
       <div data-testid="has-error">{(error ? 'true' : 'false')}</div>
         <div data-testid="current-org-id">{sessionData?.currentOrganizationId || 'none'}</div>
-        <div data-testid="user-id">{'user' in (sessionData || {}) ? (sessionData as any).user?.id : 'none'}</div>
+        <div data-testid="user-id">{'user' in (sessionData || {}) ? (sessionData as SessionDataWithUser).user?.id : 'none'}</div>
       <button 
         data-testid="refresh-button" 
         onClick={() => refreshSession()}

--- a/src/tests/integration/AppRoutes.spec.tsx
+++ b/src/tests/integration/AppRoutes.spec.tsx
@@ -101,29 +101,29 @@ describe('App', () => {
     expect(screen.getByTestId('app-providers')).toBeInTheDocument();
   });
 
-  it('renders landing page for root path', () => {
+  it('renders landing page for root path', async () => {
     renderApp(['/']);
-    expect(screen.getByTestId('landing-page')).toBeInTheDocument();
+    expect(await screen.findByTestId('landing-page')).toBeInTheDocument();
   });
 
-  it('renders auth page for /auth path', () => {
+  it('renders auth page for /auth path', async () => {
     renderApp(['/auth']);
-    expect(screen.getByTestId('auth-page')).toBeInTheDocument();
+    expect(await screen.findByTestId('auth-page')).toBeInTheDocument();
   });
 
-  it('renders support page for /support path', () => {
+  it('renders support page for /support path', async () => {
     renderApp(['/support']);
-    expect(screen.getByTestId('support-page')).toBeInTheDocument();
+    expect(await screen.findByTestId('support-page')).toBeInTheDocument();
   });
 
-  it('renders terms page for /terms-of-service path', () => {
+  it('renders terms page for /terms-of-service path', async () => {
     renderApp(['/terms-of-service']);
-    expect(screen.getByTestId('terms-page')).toBeInTheDocument();
+    expect(await screen.findByTestId('terms-page')).toBeInTheDocument();
   });
 
-  it('renders privacy page for /privacy-policy path', () => {
+  it('renders privacy page for /privacy-policy path', async () => {
     renderApp(['/privacy-policy']);
-    expect(screen.getByTestId('privacy-page')).toBeInTheDocument();
+    expect(await screen.findByTestId('privacy-page')).toBeInTheDocument();
   });
 
   it('contains app providers', () => {
@@ -145,8 +145,8 @@ describe('App', () => {
     );
   });
 
-  it('renders TopBar component on dashboard route', () => {
+  it('renders TopBar component on dashboard route', async () => {
     renderApp(['/dashboard']);
-    expect(screen.getByTestId('top-bar')).toBeInTheDocument();
+    expect(await screen.findByTestId('top-bar')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- reduce initial JS bundle via React.lazy and Suspense
- tighten session hook tests by removing `any`
- adjust integration tests for async page loading

## Testing
- `npm run lint`
- `npx vitest run`
- `npm run build`
- `npx size-limit` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a7decffa04832583afc60a60daf186