### PR TITLE
Add idempotency table for webhooks

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1428,6 +1428,21 @@ export type Database = {
           },
         ]
       }
+      webhook_events: {
+        Row: {
+          event_id: string
+          processed_at: string
+        }
+        Insert: {
+          event_id: string
+          processed_at?: string
+        }
+        Update: {
+          event_id?: string
+          processed_at?: string
+        }
+        Relationships: []
+      }
       work_order_costs: {
         Row: {
           created_at: string

--- a/src/tests/billing/webhook-idempotency.test.ts
+++ b/src/tests/billing/webhook-idempotency.test.ts
@@ -1,0 +1,223 @@
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { supabase } from '@/integrations/supabase/client';
+
+// Mock the supabase client
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: vi.fn(() => ({
+      insert: vi.fn(),
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: vi.fn()
+        }))
+      }))
+    }))
+  }
+}));
+
+describe('Webhook Event Idempotency', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('webhook_events Table Gating', () => {
+    it('should allow first-time event processing', async () => {
+      const mockInsert = vi.fn().mockResolvedValue({
+        data: [{ event_id: 'evt_new_123', processed_at: '2024-01-01T00:00:00Z' }],
+        error: null
+      });
+
+      (supabase.from as any).mockReturnValue({
+        insert: mockInsert
+      });
+
+      const eventId = 'evt_new_123';
+      const result = await supabase.from('webhook_events').insert({ event_id: eventId });
+      
+      expect(result.error).toBeNull();
+      expect(mockInsert).toHaveBeenCalledWith({ event_id: eventId });
+    });
+
+    it('should prevent duplicate event processing with unique constraint violation', async () => {
+      const mockInsert = vi.fn().mockRejectedValueOnce({
+        code: '23505', // PostgreSQL unique constraint violation
+        message: 'duplicate key value violates unique constraint "webhook_events_pkey"',
+        details: 'Key (event_id)=(evt_duplicate_456) already exists.'
+      });
+
+      (supabase.from as any).mockReturnValue({
+        insert: mockInsert
+      });
+
+      const eventId = 'evt_duplicate_456';
+      
+      try {
+        await supabase.from('webhook_events').insert({ event_id: eventId });
+      } catch (error: any) {
+        expect(error.code).toBe('23505');
+        expect(error.message).toContain('duplicate key value violates unique constraint');
+        expect(mockInsert).toHaveBeenCalledWith({ event_id: eventId });
+      }
+    });
+
+    it('should handle various Stripe event types for idempotency', async () => {
+      const stripeEventTypes = [
+        'checkout.session.completed',
+        'invoice.payment_succeeded',
+        'invoice.payment_failed',
+        'customer.subscription.updated',
+        'customer.subscription.deleted',
+        'customer.subscription.trial_will_end',
+        'customer.subscription.paused',
+        'customer.subscription.resumed'
+      ];
+
+      for (const eventType of stripeEventTypes) {
+        const mockInsert = vi.fn().mockResolvedValue({
+          data: [{ event_id: `evt_${eventType}_123`, processed_at: '2024-01-01T00:00:00Z' }],
+          error: null
+        });
+
+        (supabase.from as any).mockReturnValue({
+          insert: mockInsert
+        });
+
+        const eventId = `evt_${eventType}_123`;
+        const result = await supabase.from('webhook_events').insert({ event_id: eventId });
+        
+        expect(result.error).toBeNull();
+        expect(mockInsert).toHaveBeenCalledWith({ event_id: eventId });
+      }
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should handle database connection errors gracefully', async () => {
+      const mockInsert = vi.fn().mockRejectedValueOnce({
+        code: '08006', // Connection failure
+        message: 'could not connect to server'
+      });
+
+      (supabase.from as any).mockReturnValue({
+        insert: mockInsert
+      });
+
+      const eventId = 'evt_connection_error_789';
+      
+      try {
+        await supabase.from('webhook_events').insert({ event_id: eventId });
+      } catch (error: any) {
+        expect(error.code).toBe('08006');
+        expect(error.message).toContain('could not connect to server');
+      }
+    });
+
+    it('should differentiate between duplicate events and other errors', async () => {
+      const duplicateError = {
+        code: '23505',
+        message: 'duplicate key value violates unique constraint'
+      };
+
+      const otherError = {
+        code: '42P01', // Undefined table
+        message: 'relation "webhook_events" does not exist'
+      };
+
+      // Test duplicate error
+      let mockInsert = vi.fn().mockRejectedValueOnce(duplicateError);
+      (supabase.from as any).mockReturnValue({ insert: mockInsert });
+
+      try {
+        await supabase.from('webhook_events').insert({ event_id: 'evt_dup_123' });
+      } catch (error: any) {
+        expect(error.code).toBe('23505');
+      }
+
+      // Test other error
+      mockInsert = vi.fn().mockRejectedValueOnce(otherError);
+      (supabase.from as any).mockReturnValue({ insert: mockInsert });
+
+      try {
+        await supabase.from('webhook_events').insert({ event_id: 'evt_other_123' });
+      } catch (error: any) {
+        expect(error.code).toBe('42P01');
+      }
+    });
+  });
+
+  describe('Audit Trail Preservation', () => {
+    it('should continue logging to stripe_event_logs for audit purposes', async () => {
+      const mockInsert = vi.fn().mockResolvedValue({
+        data: [{ id: 'log_123' }],
+        error: null
+      });
+
+      (supabase.from as any).mockReturnValue({
+        insert: mockInsert
+      });
+
+      const eventLog = {
+        event_id: 'evt_audit_123',
+        type: 'invoice.payment_succeeded',
+        subscription_id: 'sub_123',
+        payload: { test: 'data' }
+      };
+
+      const result = await supabase.from('stripe_event_logs').insert(eventLog);
+      
+      expect(result.error).toBeNull();
+      expect(mockInsert).toHaveBeenCalledWith(eventLog);
+    });
+  });
+
+  describe('Event ID Format Validation', () => {
+    it('should handle various Stripe event ID formats', async () => {
+      const eventIdFormats = [
+        'evt_1A2B3C4D5E6F7G8H',
+        'evt_test_1234567890abcdef',
+        'evt_live_webhook_endpoint_1234',
+        'evt_00000000000000'
+      ];
+
+      for (const eventId of eventIdFormats) {
+        const mockInsert = vi.fn().mockResolvedValue({
+          data: [{ event_id: eventId, processed_at: '2024-01-01T00:00:00Z' }],
+          error: null
+        });
+
+        (supabase.from as any).mockReturnValue({
+          insert: mockInsert
+        });
+
+        const result = await supabase.from('webhook_events').insert({ event_id: eventId });
+        
+        expect(result.error).toBeNull();
+        expect(mockInsert).toHaveBeenCalledWith({ event_id: eventId });
+      }
+    });
+  });
+
+  describe('Timestamp Handling', () => {
+    it('should automatically set processed_at timestamp', async () => {
+      const mockInsert = vi.fn().mockResolvedValue({
+        data: [{ 
+          event_id: 'evt_timestamp_123', 
+          processed_at: new Date().toISOString() 
+        }],
+        error: null
+      });
+
+      (supabase.from as any).mockReturnValue({
+        insert: mockInsert
+      });
+
+      const eventId = 'evt_timestamp_123';
+      const result = await supabase.from('webhook_events').insert({ event_id: eventId });
+      
+      expect(result.error).toBeNull();
+      expect(mockInsert).toHaveBeenCalledWith({ event_id: eventId });
+      // The processed_at timestamp is set by the database default
+    });
+  });
+});

--- a/supabase/migrations/20250822053704_27f3ea3b-c17f-451a-87aa-b4bc61b4d594.sql
+++ b/supabase/migrations/20250822053704_27f3ea3b-c17f-451a-87aa-b4bc61b4d594.sql
@@ -1,0 +1,41 @@
+
+-- Create idempotency table for webhook events
+CREATE TABLE IF NOT EXISTS public.webhook_events (
+  event_id text PRIMARY KEY,
+  processed_at timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.webhook_events IS 'Idempotency gate for external webhooks (e.g., Stripe). A row per processed event_id.';
+
+-- Enable Row Level Security (RLS)
+ALTER TABLE public.webhook_events ENABLE ROW LEVEL SECURITY;
+
+-- Policies: Only service role (edge functions) can access. No user access.
+-- Insert policy for service role
+CREATE POLICY service_role_insert_webhook_events
+  ON public.webhook_events
+  FOR INSERT
+  TO public
+  WITH CHECK (auth.role() = 'service_role');
+
+-- Select policy for service role
+CREATE POLICY service_role_select_webhook_events
+  ON public.webhook_events
+  FOR SELECT
+  TO public
+  USING (auth.role() = 'service_role');
+
+-- Update policy for service role (not needed, but added for completeness)
+CREATE POLICY service_role_update_webhook_events
+  ON public.webhook_events
+  FOR UPDATE
+  TO public
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+-- Delete policy for service role (rarely needed)
+CREATE POLICY service_role_delete_webhook_events
+  ON public.webhook_events
+  FOR DELETE
+  TO public
+  USING (auth.role() = 'service_role');


### PR DESCRIPTION
Run SQL migration to create `webhook_events` table and associated policies for Stripe webhook idempotency.