### PR TITLE
Enhance work order assignment functionality

### DIFF
--- a/src/components/work-orders/WorkOrderAssignmentSelector.tsx
+++ b/src/components/work-orders/WorkOrderAssignmentSelector.tsx
@@ -34,8 +34,11 @@ const WorkOrderAssignmentSelector: React.FC<WorkOrderAssignmentSelectorProps> = 
         workOrderId: workOrder.id,
         assigneeId: null,
         organizationId
+      }, {
+        onSuccess: () => {
+          onCancel();
+        }
       });
-      onCancel();
       return;
     }
 
@@ -46,8 +49,11 @@ const WorkOrderAssignmentSelector: React.FC<WorkOrderAssignmentSelectorProps> = 
       workOrderId: workOrder.id,
       assigneeId: option.id,
       organizationId
+    }, {
+      onSuccess: () => {
+        onCancel();
+      }
     });
-    onCancel();
   };
 
   const getCurrentAssignmentValue = () => {

--- a/src/hooks/useQuickWorkOrderAssignment.ts
+++ b/src/hooks/useQuickWorkOrderAssignment.ts
@@ -40,9 +40,13 @@ export const useQuickWorkOrderAssignment = () => {
 
       if (error) throw error;
     },
-    onSuccess: (_, { assigneeId, organizationId }) => {
+    onSuccess: (_, { assigneeId, organizationId, workOrderId }) => {
       const message = assigneeId ? 'Work order assigned successfully' : 'Work order unassigned successfully';
       toast.success(message);
+      
+      // Invalidate specific work order queries (used by work order details page)
+      queryClient.invalidateQueries({ queryKey: ['workOrder', organizationId, workOrderId] });
+      queryClient.invalidateQueries({ queryKey: ['workOrder', 'enhanced', organizationId, workOrderId] });
       
       // Invalidate all work order related queries with partial matching
       queryClient.invalidateQueries({ queryKey: ['enhanced-work-orders', organizationId] });


### PR DESCRIPTION
This commit updates the WorkOrderAssignmentSelector component and the useQuickWorkOrderAssignment hook to improve the handling of work order assignments. Key changes include:
- Added onSuccess callbacks to the assignment functions to trigger the onCancel function after a successful assignment or unassignment.
- Updated the onSuccess handler to invalidate specific work order queries, ensuring that the work order details page reflects the latest data.

These modifications aim to enhance user experience by providing immediate feedback and ensuring data consistency across the application.

Closes #228