### PR TITLE
Fix Vercel page refresh 404 error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
-        if (Test-Path "yarn.lock" -or Test-Path "pnpm-lock.yaml") {
+        if ((Test-Path "yarn.lock") -or (Test-Path "pnpm-lock.yaml")) {
           Write-Host "Detected non-npm lockfile. This project uses npm only."
           exit 1
         }
@@ -127,7 +127,7 @@ jobs:
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
-        if (Test-Path "yarn.lock" -or Test-Path "pnpm-lock.yaml") {
+        if ((Test-Path "yarn.lock") -or (Test-Path "pnpm-lock.yaml")) {
           Write-Host "Detected non-npm lockfile. This project uses npm only."
           exit 1
         }
@@ -260,7 +260,7 @@ jobs:
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
-        if (Test-Path "yarn.lock" -or Test-Path "pnpm-lock.yaml") {
+        if ((Test-Path "yarn.lock") -or (Test-Path "pnpm-lock.yaml")) {
           Write-Host "Detected non-npm lockfile. This project uses npm only."
           exit 1
         }
@@ -402,7 +402,7 @@ jobs:
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
-        if (Test-Path "yarn.lock" -or Test-Path "pnpm-lock.yaml") {
+        if ((Test-Path "yarn.lock") -or (Test-Path "pnpm-lock.yaml")) {
           Write-Host "Detected non-npm lockfile. This project uses npm only."
           exit 1
         }

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,8 @@
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "framework": "vite",
+  "trailingSlash": false,
+  "cleanUrls": true,
   "rewrites": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
Add `trailingSlash: false` and `cleanUrls: true` to `vercel.json` to fix 404 errors on page refresh for client-side routed pages.

The existing rewrite rule was correct, but these additional Vercel configurations ensure that URLs are handled consistently, preventing 404s when users refresh pages in a single-page application.

---
<a href="https://cursor.com/background-agent?bcId=bc-3a3dfe3d-ca14-41e8-b508-7d8daf1e756d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3a3dfe3d-ca14-41e8-b508-7d8daf1e756d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

