### PR TITLE
Fix Vercel page refresh 404 error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,12 +1,11 @@
 {
+  "version": 2,
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "framework": "vite",
-  "rewrites": [
-    {
-      "source": "/(.*)",
-      "destination": "/index.html"
-    }
+  "routes": [
+    { "handle": "filesystem" },
+    { "src": "/.*", "dest": "/index.html" }
   ],
   "headers": [
     {


### PR DESCRIPTION
Add Vercel `version: 2` and `routes` configuration to correctly serve `index.html` for client-side routes, fixing 404 errors on refresh.

---
<a href="https://cursor.com/background-agent?bcId=bc-f154aaca-649b-4044-813d-72acfa6cfe57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f154aaca-649b-4044-813d-72acfa6cfe57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

