### PR TITLE
Fix Vercel page refresh 404 error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,11 +2,9 @@
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "framework": "vite",
-  "rewrites": [
-    {
-      "source": "/(.*)",
-      "destination": "/index.html"
-    }
+  "routes": [
+    { "handle": "filesystem" },
+    { "src": "/(.*)", "dest": "/index.html" }
   ],
   "headers": [
     {


### PR DESCRIPTION
Configure `vercel.json` with filesystem-first routing and a SPA fallback to `index.html` to fix 404 errors on refresh.

---
<a href="https://cursor.com/background-agent?bcId=bc-75049d18-0bf1-48fa-9d39-5b039d6c9e20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-75049d18-0bf1-48fa-9d39-5b039d6c9e20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

