### PR TITLE
Fix 404 errors on Vercel deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,7 @@
   "cleanUrls": true,
   "rewrites": [
     {
-      "source": "/(.*)",
+      "source": "/((?!api/).*)",
       "destination": "/index.html"
     }
   ],


### PR DESCRIPTION
Update `vercel.json` rewrite rule to fix 404 errors on page refresh for client-side routes.

The previous rewrite rule was too broad, causing Vercel to attempt to serve non-existent physical files for client-side routes. The updated rule uses a negative lookahead to exclude API routes and correctly redirects all other paths to `index.html`, allowing React Router to handle them.

---
<a href="https://cursor.com/background-agent?bcId=bc-ddf9e555-3083-47dd-9fa1-7ead2d1ff1af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ddf9e555-3083-47dd-9fa1-7ead2d1ff1af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

